### PR TITLE
Make $capabilities initialize param optional

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -58,7 +58,7 @@ class LanguageServer extends \AdvancedJsonRpc\Dispatcher
      * @param ClientCapabilities $capabilities The capabilities provided by the client (editor)
      * @return InitializeResult
      */
-    public function initialize(string $rootPath, int $processId, ClientCapabilities $capabilities): InitializeResult
+    public function initialize(string $rootPath, int $processId, ClientCapabilities $capabilities = null): InitializeResult
     {
         $serverCapabilities = new ServerCapabilities();
         // Ask the client to return always full documents (because we need to rebuild the AST from scratch)


### PR DESCRIPTION
Eclipse Che does not pass ClientCapabilities in InitializeParams. This
works well with other language server, but not with this one.

The issue is resolved by making the $capabilities param optional.