### PR TITLE
Variable symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .vscode
+.idea
 vendor/
 composer.lock

--- a/src/SymbolFinder.php
+++ b/src/SymbolFinder.php
@@ -44,8 +44,8 @@ class SymbolFinder extends NodeVisitorAbstract
     {
         $class = get_class($node);
         if (!isset(self::NODE_SYMBOL_KIND_MAP[$class])) {
-        return;
-    }
+            return;
+        }
 
         $symbol = end($this->symbols);
         $kind = self::NODE_SYMBOL_KIND_MAP[$class];

--- a/src/SymbolFinder.php
+++ b/src/SymbolFinder.php
@@ -23,7 +23,7 @@ class SymbolFinder extends NodeVisitorAbstract
     /**
      * @var \LanguageServer\Protocol\SymbolInformation[]
      */
-    public $symbols;
+    public $symbols = [];
 
     /**
      * @var string

--- a/tests/Server/TextDocumentTest.php
+++ b/tests/Server/TextDocumentTest.php
@@ -24,7 +24,7 @@ class TextDocumentTest extends TestCase
         // Request symbols
         $result = $textDocument->documentSymbol(new TextDocumentIdentifier('whatever'));
         $this->assertEquals([
-           [
+            [
                 'name' => 'TestNamespace',
                 'kind' => SymbolKind::NAMESPACE,
                 'location' => [
@@ -91,24 +91,6 @@ class TextDocumentTest extends TestCase
                         'end' => [
                             'line' => 11,
                             'character' => 4
-                        ]
-                    ]
-                ],
-                'containerName' => null
-            ],
-            [
-                'name' => 'testVariable',
-                'kind' => SymbolKind::VARIABLE,
-                'location' => [
-                    'uri' => 'whatever',
-                    'range' => [
-                        'start' => [
-                            'line' => 10,
-                            'character' => 8
-                        ],
-                        'end' => [
-                            'line' => 10,
-                            'character' => 20
                         ]
                     ]
                 ],
@@ -197,7 +179,7 @@ class TextDocumentTest extends TestCase
             ]]
         ], json_decode(json_encode($args), true));
     }
-    
+
     public function testFormatting()
     {
         $textDocument = new Server\TextDocument(new LanguageClient(new MockProtocolStream()));
@@ -208,7 +190,7 @@ class TextDocumentTest extends TestCase
         $textDocumentItem->version = 1;
         $textDocumentItem->text = file_get_contents(__DIR__ . '/../../fixtures/format.php');
         $textDocument->didOpen($textDocumentItem);
-        
+
         // how code should look after formatting
         $expected = file_get_contents(__DIR__ . '/../../fixtures/format_expected.php');
         // Request formatting


### PR DESCRIPTION
We should exclude variable symbols that are defined in function and method body.