### PR TITLE
Add phpunit configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
  - composer install
 
 script:
- - vendor/bin/phpunit --coverage-clover=coverage.xml --whitelist src --bootstrap vendor/autoload.php tests
+ - vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+	<testsuites>
+		<testsuite name="PHP Language Server Test Suite">
+			<directory>./tests</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<whitelist>
+			<directory>./src</directory>
+		</whitelist>
+	</filter>
+</phpunit>


### PR DESCRIPTION
This file will preconfigure phpunit options. No need to write 'vendor/bin/phpunit --bootstrap vendor/autoload.php tests' anymore.