### PR TITLE
Hover

### DIFF
--- a/fixtures/global_references.php
+++ b/fixtures/global_references.php
@@ -13,6 +13,12 @@ test_function();
 $var = 123;
 echo $var;
 
+/**
+ * Aute duis elit reprehenderit tempor cillum proident anim laborum eu laboris reprehenderit ea incididunt.
+ *
+ * @param TestClass $param Adipisicing non non cillum sint incididunt cillum enim mollit.
+ * @return TestClass
+ */
 function whatever(TestClass $param): TestClass {
     echo $param;
 }

--- a/fixtures/global_symbols.php
+++ b/fixtures/global_symbols.php
@@ -2,19 +2,59 @@
 
 
 
+/**
+ * Esse commodo excepteur pariatur Lorem est aute incididunt reprehenderit.
+ *
+ * @var int
+ */
 const TEST_CONST = 123;
 
+/**
+ * Pariatur ut laborum tempor voluptate consequat ea deserunt.
+ *
+ * Deserunt enim minim sunt sint ea nisi. Deserunt excepteur tempor id nostrud
+ * laboris commodo ad commodo velit mollit qui non officia id. Nulla duis veniam
+ * veniam officia deserunt et non dolore mollit ea quis eiusmod sit non. Occaecat
+ * consequat sunt culpa exercitation pariatur id reprehenderit nisi incididunt Lorem
+ * sint. Officia culpa pariatur laborum nostrud cupidatat consequat mollit.
+ */
 class TestClass implements TestInterface
 {
+    /**
+     * Anim labore veniam consectetur laboris minim quis aute aute esse nulla ad.
+     *
+     * @var int
+     */
     const TEST_CLASS_CONST = 123;
+
+    /**
+     * Lorem excepteur officia sit anim velit veniam enim.
+     *
+     * @var TestClass
+     */
     public static $staticTestProperty;
+
+    /**
+     * Reprehenderit magna velit mollit ipsum do.
+     *
+     * @var TestClass
+     */
     public $testProperty;
 
+    /**
+     * Do magna consequat veniam minim proident eiusmod incididunt aute proident.
+     */
     public static function staticTestMethod()
     {
 
     }
 
+    /**
+     * Non culpa nostrud mollit esse sunt laboris in irure ullamco cupidatat amet.
+     *
+     * @param TestClass $testParameter Lorem sunt velit incididunt mollit
+     * @return TestClass
+     */
     public function testMethod($testParameter)
     {
         $testVariable = 123;
@@ -31,6 +71,11 @@ interface TestInterface
 
 }
 
+/**
+ * Officia aliquip adipisicing et nulla et laboris dolore labore.
+ *
+ * @return void
+ */
 function test_function()
 {
 

--- a/fixtures/references.php
+++ b/fixtures/references.php
@@ -13,6 +13,12 @@ test_function();
 $var = 123;
 echo $var;
 
+/**
+ * Aute duis elit reprehenderit tempor cillum proident anim laborum eu laboris reprehenderit ea incididunt.
+ *
+ * @param TestClass $param Adipisicing non non cillum sint incididunt cillum enim mollit.
+ * @return TestClass
+ */
 function whatever(TestClass $param): TestClass {
     echo $param;
 }

--- a/fixtures/symbols.php
+++ b/fixtures/symbols.php
@@ -2,19 +2,59 @@
 
 namespace TestNamespace;
 
+/**
+ * Esse commodo excepteur pariatur Lorem est aute incididunt reprehenderit.
+ *
+ * @var int
+ */
 const TEST_CONST = 123;
 
+/**
+ * Pariatur ut laborum tempor voluptate consequat ea deserunt.
+ *
+ * Deserunt enim minim sunt sint ea nisi. Deserunt excepteur tempor id nostrud
+ * laboris commodo ad commodo velit mollit qui non officia id. Nulla duis veniam
+ * veniam officia deserunt et non dolore mollit ea quis eiusmod sit non. Occaecat
+ * consequat sunt culpa exercitation pariatur id reprehenderit nisi incididunt Lorem
+ * sint. Officia culpa pariatur laborum nostrud cupidatat consequat mollit.
+ */
 class TestClass implements TestInterface
 {
+    /**
+     * Anim labore veniam consectetur laboris minim quis aute aute esse nulla ad.
+     *
+     * @var int
+     */
     const TEST_CLASS_CONST = 123;
+
+    /**
+     * Lorem excepteur officia sit anim velit veniam enim.
+     *
+     * @var TestClass
+     */
     public static $staticTestProperty;
+
+    /**
+     * Reprehenderit magna velit mollit ipsum do.
+     *
+     * @var TestClass
+     */
     public $testProperty;
 
+    /**
+     * Do magna consequat veniam minim proident eiusmod incididunt aute proident.
+     */
     public static function staticTestMethod()
     {
 
     }
 
+    /**
+     * Non culpa nostrud mollit esse sunt laboris in irure ullamco cupidatat amet.
+     *
+     * @param TestClass $testParameter Lorem sunt velit incididunt mollit
+     * @return TestClass
+     */
     public function testMethod($testParameter)
     {
         $testVariable = 123;
@@ -31,6 +71,11 @@ interface TestInterface
 
 }
 
+/**
+ * Officia aliquip adipisicing et nulla et laboris dolore labore.
+ *
+ * @return void
+ */
 function test_function()
 {
 

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -107,6 +107,8 @@ class LanguageServer extends \AdvancedJsonRpc\Dispatcher
         $serverCapabilities->definitionProvider = true;
         // Support "Find all references"
         $serverCapabilities->referencesProvider = true;
+        // Support "Hover"
+        $serverCapabilities->hoverProvider = true;
 
         return new InitializeResult($serverCapabilities);
     }

--- a/src/NodeVisitor/DocBlockParser.php
+++ b/src/NodeVisitor/DocBlockParser.php
@@ -5,6 +5,7 @@ namespace LanguageServer\NodeVisitor;
 
 use PhpParser\{NodeVisitorAbstract, Node};
 use phpDocumentor\Reflection\DocBlockFactory;
+use phpDocumentor\Reflection\Types\Context;
 
 /**
  * Decorates all nodes with a docBlock attribute that is an instance of phpDocumentor\Reflection\DocBlock
@@ -16,18 +17,52 @@ class DocBlockParser extends NodeVisitorAbstract
      */
     private $docBlockFactory;
 
+    /**
+     * The current namespace context
+     *
+     * @var string
+     */
+    private $namespace;
+
+    /**
+     * Namespace aliases in the current context
+     *
+     * @var string[]
+     */
+    private $aliases;
+
     public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
 
+    public function beforeTraverse(array $nodes)
+    {
+        $this->namespace = '';
+        $this->aliases = [];
+    }
+
     public function enterNode(Node $node)
     {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            $this->namespace = (string)$node->name;
+        } else if ($node instanceof Node\Stmt\UseUse) {
+            $this->aliases[(string)$node->name] = $node->alias;
+        }
         $docComment = $node->getDocComment();
         if ($docComment === null) {
             return;
         }
-        $docBlock = $this->docBlockFactory->create($docComment->getText());
+        $context = new Context($this->namespace, $this->aliases);
+        $docBlock = $this->docBlockFactory->create($docComment->getText(), $context);
         $node->setAttribute('docBlock', $docBlock);
+    }
+
+    public function leaveNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\Namespace_) {
+            $this->namespace = '';
+            $this->aliases = [];
+        }
     }
 }

--- a/src/NodeVisitor/DocBlockParser.php
+++ b/src/NodeVisitor/DocBlockParser.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\NodeVisitor;
+
+use PhpParser\{NodeVisitorAbstract, Node};
+use phpDocumentor\Reflection\DocBlockFactory;
+
+/**
+ * Decorates all nodes with a docBlock attribute that is an instance of phpDocumentor\Reflection\DocBlock
+ */
+class DocBlockParser extends NodeVisitorAbstract
+{
+    /**
+     * @var DocBlockFactory
+     */
+    private $docBlockFactory;
+
+    public function __construct(DocBlockFactory $docBlockFactory)
+    {
+        $this->docBlockFactory = $docBlockFactory;
+    }
+
+    public function enterNode(Node $node)
+    {
+        $docComment = $node->getDocComment();
+        if ($docComment === null) {
+            return;
+        }
+        $docBlock = $this->docBlockFactory->create($docComment->getText());
+        $node->setAttribute('docBlock', $docBlock);
+    }
+}

--- a/src/Project.php
+++ b/src/Project.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace LanguageServer;
 
+use phpDocumentor\Reflection\DocBlockFactory;
 use PhpParser\{ParserFactory, Lexer};
 
 class Project
@@ -37,6 +38,13 @@ class Project
     private $parser;
 
     /**
+     * The DocBlockFactory instance to parse docblocks
+     *
+     * @var DocBlockFactory
+     */
+    private $docBlockFactory;
+
+    /**
      * Reference to the language server client interface
      *
      * @var LanguageClient
@@ -49,6 +57,7 @@ class Project
 
         $lexer = new Lexer(['usedAttributes' => ['comments', 'startLine', 'endLine', 'startFilePos', 'endFilePos']]);
         $this->parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7, $lexer, ['throwOnError' => false]);
+        $this->docBlockFactory = DocBlockFactory::createInstance();
     }
 
     /**
@@ -81,7 +90,7 @@ class Project
             $document = $this->documents[$uri];
             $document->updateContent($content);
         } else {
-            $document = new PhpDocument($uri, $content, $this, $this->client, $this->parser);
+            $document = new PhpDocument($uri, $content, $this, $this->client, $this->parser, $this->docBlockFactory);
         }
         return $document;
     }
@@ -99,7 +108,7 @@ class Project
             $document = $this->documents[$uri];
             $document->updateContent($content);
         } else {
-            $document = new PhpDocument($uri, $content, $this, $this->client, $this->parser);
+            $document = new PhpDocument($uri, $content, $this, $this->client, $this->parser, $this->docBlockFactory);
             $this->documents[$uri] = $document;
         }
         return $document;

--- a/src/Protocol/Diagnostic.php
+++ b/src/Protocol/Diagnostic.php
@@ -2,6 +2,8 @@
 
 namespace LanguageServer\Protocol;
 
+use PhpParser\Error;
+
 /**
  * Represents a diagnostic, such as a compiler error or warning. Diagnostic objects are only valid in the scope of a
  * resource.
@@ -44,4 +46,40 @@ class Diagnostic
      * @var string
      */
     public $message;
+
+    /**
+     * Creates a diagnostic from a PhpParser Error
+     *
+     * @param  Error  $error    Message and code will be used
+     * @param  string $content  The file content to calculate the column info
+     * @param  int    $severity DiagnosticSeverity
+     * @param  string $source   A human-readable string describing the source of this diagnostic
+     * @return self
+     */
+    public static function fromError(Error $error, string $content, int $severity = null, string $source = null): self
+    {
+        return new self(
+            $error->getRawMessage(), // Do not include "on line ..." in the error message
+            Range::fromError($error, $content),
+            $error->getCode(),
+            $severity,
+            $source
+        );
+    }
+
+    /**
+     * @param  string $message  The diagnostic's message
+     * @param  Range  $range    The range at which the message applies
+     * @param  int    $code     The diagnostic's code
+     * @param  int    $severity DiagnosticSeverity
+     * @param  string $source   A human-readable string describing the source of this diagnostic
+     */
+    public function __construct(string $message = null, Range $range = null, int $code = null, int $severity = null, string $source = null)
+    {
+        $this->message = $message;
+        $this->range = $range;
+        $this->code = $code;
+        $this->severity = $severity;
+        $this->source = $source;
+    }
 }

--- a/src/Protocol/Hover.php
+++ b/src/Protocol/Hover.php
@@ -10,7 +10,7 @@ class Hover
     /**
      * The hover's content
      *
-     * @var string|MarkedString|(string|MarkedString)[]
+     * @var string|MarkedString|string[]|MarkedString[]
      */
     public $contents;
 
@@ -22,7 +22,7 @@ class Hover
     public $range;
 
     /**
-     * @param string|MarkedString|(string|MarkedString)[] $contents The hover's content
+     * @param string|MarkedString|string[]|MarkedString[] $contents The hover's content
      * @param Range $range An optional range
      */
     public function __construct($contents = null, $range = null)

--- a/src/Protocol/Hover.php
+++ b/src/Protocol/Hover.php
@@ -10,7 +10,7 @@ class Hover
     /**
      * The hover's content
      *
-     * @var string|string[]|MarkedString|MarkedString[]
+     * @var string|MarkedString|(string|MarkedString)[]
      */
     public $contents;
 
@@ -20,4 +20,14 @@ class Hover
      * @var Range|null
      */
     public $range;
+
+    /**
+     * @param string|MarkedString|(string|MarkedString)[] $contents The hover's content
+     * @param Range $range An optional range
+     */
+    public function __construct($contents = null, $range = null)
+    {
+        $this->contents = $contents;
+        $this->range = $range;
+    }
 }

--- a/src/Protocol/MarkedString.php
+++ b/src/Protocol/MarkedString.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LanguageServer\Protocol;
+
+class MarkedString
+{
+    /**
+     * @var string
+     */
+    public $language;
+
+    /**
+     * @var string
+     */
+    public $value;
+
+    public function __construct(string $language = null, string $value = null)
+    {
+        $this->language = $language;
+        $this->value = $value;
+    }
+}

--- a/src/Protocol/Range.php
+++ b/src/Protocol/Range.php
@@ -2,7 +2,7 @@
 
 namespace LanguageServer\Protocol;
 
-use PhpParser\Node;
+use PhpParser\{Error, Node};
 
 /**
  * A range in a text document expressed as (zero-based) start and end positions.
@@ -35,6 +35,22 @@ class Range
             new Position($node->getAttribute('startLine') - 1, $node->getAttribute('startColumn') - 1),
             new Position($node->getAttribute('endLine') - 1, $node->getAttribute('endColumn'))
         );
+    }
+
+    /**
+     * Returns the range where an error occured
+     *
+     * @param \PhpParser\Error $error
+     * @param string $content
+     * @return self
+     */
+    public static function fromError(Error $error, string $content)
+    {
+        $startLine   = max($error->getStartLine() - 1, 0);
+        $endLine     = max($error->getEndLine() - 1, $startLine);
+        $startColumn = $error->hasColumnInfo() ? $error->getStartColumn($content) - 1 : 0;
+        $endColumn   = $error->hasColumnInfo() ? $error->getEndColumn($content) : 0;
+        return new self(new Position($startLine, $startColumn), new Position($endLine, $endColumn));
     }
 
     public function __construct(Position $start = null, Position $end = null)

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -178,10 +178,6 @@ class TextDocument
             return null;
         }
         $contents = [];
-        $docBlock = $def->getAttribute('docBlock');
-        if ($docBlock !== null) {
-            $contents[] = $docBlock->getSummary();
-        }
         $defLine = clone $def;
         $defLine->setAttribute('comments', []);
         if (isset($defLine->stmts)) {
@@ -190,7 +186,11 @@ class TextDocument
         $defText = $this->prettyPrinter->prettyPrint([$defLine]);
         $lines = explode("\n", $defText);
         if (isset($lines[0])) {
-            $contents[] = new MarkedString('php', $lines[0]);
+            $contents[] = new MarkedString('php', "<?php\n" . $lines[0]);
+        }
+        $docBlock = $def->getAttribute('docBlock');
+        if ($docBlock !== null) {
+            $contents[] = $docBlock->getSummary();
         }
         return new Hover($contents, Range::fromNode($node));
     }

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -31,7 +31,7 @@ class LanguageServerTest extends TestCase
             'capabilities' => (object)[
                 'textDocumentSync' => TextDocumentSyncKind::FULL,
                 'documentSymbolProvider' => true,
-                'hoverProvider' => null,
+                'hoverProvider' => true,
                 'completionProvider' => null,
                 'signatureHelpProvider' => null,
                 'definitionProvider' => true,

--- a/tests/Server/ServerTestCase.php
+++ b/tests/Server/ServerTestCase.php
@@ -62,49 +62,49 @@ abstract class ServerTestCase extends TestCase
         $this->definitionLocations = [
 
             // Global
-            'TEST_CONST'                             => new Location($globalSymbolsUri,    new Range(new Position( 4,  6), new Position(4,  22))),
-            'TestClass'                              => new Location($globalSymbolsUri,    new Range(new Position( 6,  0), new Position(21,  1))),
-            'TestTrait'                              => new Location($globalSymbolsUri,    new Range(new Position(23,  0), new Position(26,  1))),
-            'TestInterface'                          => new Location($globalSymbolsUri,    new Range(new Position(28,  0), new Position(31,  1))),
-            'TestClass::TEST_CLASS_CONST'            => new Location($globalSymbolsUri,    new Range(new Position( 8, 10), new Position(8,  32))),
-            'TestClass::testProperty'                => new Location($globalSymbolsUri,    new Range(new Position(10, 11), new Position(10, 24))),
-            'TestClass::staticTestProperty'          => new Location($globalSymbolsUri,    new Range(new Position( 9, 18), new Position(9,  37))),
-            'TestClass::staticTestMethod()'          => new Location($globalSymbolsUri,    new Range(new Position(12,  4), new Position(15,  5))),
-            'TestClass::testMethod()'                => new Location($globalSymbolsUri,    new Range(new Position(17,  4), new Position(20,  5))),
-            'test_function()'                        => new Location($globalSymbolsUri,    new Range(new Position(33,  0), new Position(36,  1))),
-            'whatever()'                             => new Location($globalReferencesUri, new Range(new Position(15,  0), new Position(17,  1))),
+            'TEST_CONST'                             => new Location($globalSymbolsUri,    new Range(new Position( 9,  6), new Position( 9, 22))),
+            'TestClass'                              => new Location($globalSymbolsUri,    new Range(new Position(20,  0), new Position(61,  1))),
+            'TestTrait'                              => new Location($globalSymbolsUri,    new Range(new Position(63,  0), new Position(66,  1))),
+            'TestInterface'                          => new Location($globalSymbolsUri,    new Range(new Position(68,  0), new Position(71,  1))),
+            'TestClass::TEST_CLASS_CONST'            => new Location($globalSymbolsUri,    new Range(new Position(27, 10), new Position(27, 32))),
+            'TestClass::testProperty'                => new Location($globalSymbolsUri,    new Range(new Position(41, 11), new Position(41, 24))),
+            'TestClass::staticTestProperty'          => new Location($globalSymbolsUri,    new Range(new Position(34, 18), new Position(34, 37))),
+            'TestClass::staticTestMethod()'          => new Location($globalSymbolsUri,    new Range(new Position(46,  4), new Position(49,  5))),
+            'TestClass::testMethod()'                => new Location($globalSymbolsUri,    new Range(new Position(57,  4), new Position(60,  5))),
+            'test_function()'                        => new Location($globalSymbolsUri,    new Range(new Position(78,  0), new Position(81,  1))),
+            'whatever()'                             => new Location($globalReferencesUri, new Range(new Position(21,  0), new Position(23,  1))),
 
             // Namespaced
-            'TestNamespace\\TEST_CONST'                    => new Location($symbolsUri,    new Range(new Position( 4,  6), new Position(4,  22))),
-            'TestNamespace\\TestClass'                     => new Location($symbolsUri,    new Range(new Position( 6,  0), new Position(21,  1))),
-            'TestNamespace\\TestInterface'                 => new Location($symbolsUri,    new Range(new Position(28,  0), new Position(31,  1))),
-            'TestNamespace\\TestTrait'                     => new Location($symbolsUri,    new Range(new Position(23,  0), new Position(26,  1))),
-            'TestNamespace\\TestClass::TEST_CLASS_CONST'   => new Location($symbolsUri,    new Range(new Position( 8, 10), new Position(8,  32))),
-            'TestNamespace\\TestClass::testProperty'       => new Location($symbolsUri,    new Range(new Position(10, 11), new Position(10, 24))),
-            'TestNamespace\\TestClass::staticTestProperty' => new Location($symbolsUri,    new Range(new Position( 9, 18), new Position(9,  37))),
-            'TestNamespace\\TestClass::staticTestMethod()' => new Location($symbolsUri,    new Range(new Position(12,  4), new Position(15,  5))),
-            'TestNamespace\\TestClass::testMethod()'       => new Location($symbolsUri,    new Range(new Position(17,  4), new Position(20,  5))),
-            'TestNamespace\\test_function()'               => new Location($symbolsUri,    new Range(new Position(33,  0), new Position(36,  1))),
-            'TestNamespace\\whatever()'                    => new Location($referencesUri, new Range(new Position(15,  0), new Position(17,  1)))
+            'TestNamespace\\TEST_CONST'                    => new Location($symbolsUri,    new Range(new Position( 9,  6), new Position( 9, 22))),
+            'TestNamespace\\TestClass'                     => new Location($symbolsUri,    new Range(new Position(20,  0), new Position(61,  1))),
+            'TestNamespace\\TestTrait'                     => new Location($symbolsUri,    new Range(new Position(63,  0), new Position(66,  1))),
+            'TestNamespace\\TestInterface'                 => new Location($symbolsUri,    new Range(new Position(68,  0), new Position(71,  1))),
+            'TestNamespace\\TestClass::TEST_CLASS_CONST'   => new Location($symbolsUri,    new Range(new Position(27, 10), new Position(27,  32))),
+            'TestNamespace\\TestClass::testProperty'       => new Location($symbolsUri,    new Range(new Position(41, 11), new Position(41, 24))),
+            'TestNamespace\\TestClass::staticTestProperty' => new Location($symbolsUri,    new Range(new Position(34, 18), new Position(34, 37))),
+            'TestNamespace\\TestClass::staticTestMethod()' => new Location($symbolsUri,    new Range(new Position(46,  4), new Position(49,  5))),
+            'TestNamespace\\TestClass::testMethod()'       => new Location($symbolsUri,    new Range(new Position(57,  4), new Position(60,  5))),
+            'TestNamespace\\test_function()'               => new Location($symbolsUri,    new Range(new Position(78,  0), new Position(81,  1))),
+            'TestNamespace\\whatever()'                    => new Location($referencesUri, new Range(new Position(21,  0), new Position(23,  1)))
         ];
 
         $this->referenceLocations = [
 
             // Namespaced
             'TestNamespace\\TEST_CONST' => [
-                0 => new Location($referencesUri, new Range(new Position(23,  5), new Position(23, 15)))
+                0 => new Location($referencesUri, new Range(new Position(29,  5), new Position(29, 15)))
             ],
             'TestNamespace\\TestClass' => [
                 0 => new Location($referencesUri, new Range(new Position( 4, 11), new Position( 4, 20))), // $obj = new TestClass();
                 1 => new Location($referencesUri, new Range(new Position( 7,  0), new Position( 7,  9))), // TestClass::staticTestMethod();
                 2 => new Location($referencesUri, new Range(new Position( 8,  5), new Position( 8, 14))), // echo TestClass::$staticTestProperty;
                 3 => new Location($referencesUri, new Range(new Position( 9,  5), new Position( 9, 14))), // TestClass::TEST_CLASS_CONST;
-                4 => new Location($referencesUri, new Range(new Position(15, 18), new Position(15, 27))), // function whatever(TestClass $param)
-                5 => new Location($referencesUri, new Range(new Position(15, 37), new Position(15, 46))), // function whatever(TestClass $param): TestClass
+                4 => new Location($referencesUri, new Range(new Position(21, 18), new Position(21, 27))), // function whatever(TestClass $param)
+                5 => new Location($referencesUri, new Range(new Position(21, 37), new Position(21, 46))), // function whatever(TestClass $param): TestClass
                 6 => new Location($useUri,        new Range(new Position( 4,  4), new Position( 4, 27))), // use TestNamespace\TestClass;
             ],
             'TestNamespace\\TestInterface' => [
-                0 => new Location($symbolsUri,    new Range(new Position( 6, 27), new Position( 6, 40))) // class TestClass implements TestInterface
+                0 => new Location($symbolsUri,    new Range(new Position(20, 27), new Position(20, 40))) // class TestClass implements TestInterface
             ],
             'TestNamespace\\TestClass::TEST_CLASS_CONST' => [
                 0 => new Location($referencesUri, new Range(new Position( 9,  5), new Position( 9, 32)))
@@ -127,19 +127,19 @@ abstract class ServerTestCase extends TestCase
 
             // Global
             'TEST_CONST' => [
-                0 => new Location($referencesUri,       new Range(new Position(23,  5), new Position(23, 15))),
-                1 => new Location($globalReferencesUri, new Range(new Position(23,  5), new Position(23, 15)))
+                0 => new Location($referencesUri,       new Range(new Position(29,  5), new Position(29, 15))),
+                1 => new Location($globalReferencesUri, new Range(new Position(29,  5), new Position(29, 15)))
             ],
             'TestClass' => [
                 0 => new Location($globalReferencesUri, new Range(new Position( 4, 11), new Position( 4, 20))), // $obj = new TestClass();
                 1 => new Location($globalReferencesUri, new Range(new Position( 7,  0), new Position( 7,  9))), // TestClass::staticTestMethod();
                 2 => new Location($globalReferencesUri, new Range(new Position( 8,  5), new Position( 8, 14))), // echo TestClass::$staticTestProperty;
                 3 => new Location($globalReferencesUri, new Range(new Position( 9,  5), new Position( 9, 14))), // TestClass::TEST_CLASS_CONST;
-                4 => new Location($globalReferencesUri, new Range(new Position(15, 18), new Position(15, 27))), // function whatever(TestClass $param)
-                5 => new Location($globalReferencesUri, new Range(new Position(15, 37), new Position(15, 46))), // function whatever(TestClass $param): TestClass
+                4 => new Location($globalReferencesUri, new Range(new Position(21, 18), new Position(21, 27))), // function whatever(TestClass $param)
+                5 => new Location($globalReferencesUri, new Range(new Position(21, 37), new Position(21, 46))), // function whatever(TestClass $param): TestClass
             ],
             'TestInterface' => [
-                0 => new Location($globalSymbolsUri,    new Range(new Position( 6, 27), new Position( 6, 40)))  // class TestClass implements TestInterface
+                0 => new Location($globalSymbolsUri,    new Range(new Position(20, 27), new Position(20, 40)))  // class TestClass implements TestInterface
             ],
             'TestClass::TEST_CLASS_CONST' => [
                 0 => new Location($globalReferencesUri, new Range(new Position( 9,  5), new Position( 9, 32)))

--- a/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
@@ -32,7 +32,7 @@ class GlobalFallbackTest extends ServerTestCase
         // echo TEST_CONST;
         // Get definition for TEST_CONST
         $result = $this->textDocument->definition(new TextDocumentIdentifier('global_fallback'), new Position(6, 10));
-        $this->assertEquals(new Location('global_symbols', new Range(new Position(4, 6), new Position(4, 22))), $result);
+        $this->assertEquals(new Location('global_symbols', new Range(new Position(9, 6), new Position(9, 22))), $result);
     }
 
     public function testFallsBackForFunctions()
@@ -40,6 +40,6 @@ class GlobalFallbackTest extends ServerTestCase
         // test_function();
         // Get definition for test_function
         $result = $this->textDocument->definition(new TextDocumentIdentifier('global_fallback'), new Position(5, 6));
-        $this->assertEquals(new Location('global_symbols', new Range(new Position(33, 0), new Position(36, 1))), $result);
+        $this->assertEquals(new Location('global_symbols', new Range(new Position(78, 0), new Position(81, 1))), $result);
     }
 }

--- a/tests/Server/TextDocument/Definition/GlobalTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalTest.php
@@ -32,7 +32,7 @@ class GlobalTest extends ServerTestCase
 
     public function testDefinitionForClassOnStaticMethodCall()
     {
-        // $obj = new TestClass();
+        // TestClass::staticTestMethod();
         // Get definition for TestClass
         $reference = $this->getReferenceLocations('TestClass')[1];
         $result = $this->textDocument->definition(new TextDocumentIdentifier($reference->uri), $reference->range->start);
@@ -152,8 +152,8 @@ class GlobalTest extends ServerTestCase
         // echo $param;
         // Get definition for $param
         $uri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($uri), new Position(16, 13));
-        $this->assertEquals(new Location($uri, new Range(new Position(15, 18), new Position(15, 34))), $result);
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($uri), new Position(22, 13));
+        $this->assertEquals(new Location($uri, new Range(new Position(21, 18), new Position(21, 34))), $result);
     }
 
     public function testDefinitionForUsedVariables()
@@ -161,8 +161,8 @@ class GlobalTest extends ServerTestCase
         // echo $var;
         // Get definition for $var
         $uri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($uri), new Position(20, 11));
-        $this->assertEquals(new Location($uri, new Range(new Position(19, 22), new Position(19, 26))), $result);
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($uri), new Position(26, 11));
+        $this->assertEquals(new Location($uri, new Range(new Position(25, 22), new Position(25, 26))), $result);
     }
 
     public function testDefinitionForFunctions()

--- a/tests/Server/TextDocument/HoverTest.php
+++ b/tests/Server/TextDocument/HoverTest.php
@@ -18,8 +18,8 @@ class HoverTest extends ServerTestCase
         $reference = $this->getReferenceLocations('TestClass')[0];
         $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->start);
         $this->assertEquals(new Hover([
-            'Pariatur ut laborum tempor voluptate consequat ea deserunt.',
-            new MarkedString('php', 'class TestClass implements \\TestInterface')
+            new MarkedString('php', "<?php\nclass TestClass implements \\TestInterface"),
+            'Pariatur ut laborum tempor voluptate consequat ea deserunt.'
         ], $reference->range), $result);
     }
 
@@ -30,7 +30,7 @@ class HoverTest extends ServerTestCase
         $uri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
         $result = $this->textDocument->hover(new TextDocumentIdentifier($uri), new Position(13, 7));
         $this->assertEquals(new Hover(
-            [new MarkedString('php', '$var = 123;')],
+            [new MarkedString('php', "<?php\n\$var = 123;")],
             new Range(new Position(13, 5), new Position(13, 9))
         ), $result);
     }

--- a/tests/Server/TextDocument/HoverTest.php
+++ b/tests/Server/TextDocument/HoverTest.php
@@ -23,7 +23,91 @@ class HoverTest extends ServerTestCase
         ], $reference->range), $result);
     }
 
-    public function testHoverWithoutDocBlock()
+    public function testHoverForMethod()
+    {
+        // $obj->testMethod();
+        // Get hover for testMethod
+        $reference = $this->getReferenceLocations('TestClass::testMethod()')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\npublic function testMethod(\$testParameter)"),
+            'Non culpa nostrud mollit esse sunt laboris in irure ullamco cupidatat amet.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForProperty()
+    {
+        // echo $obj->testProperty;
+        // Get hover for testProperty
+        $reference = $this->getReferenceLocations('TestClass::testProperty')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\npublic \$testProperty;"),
+            'Reprehenderit magna velit mollit ipsum do.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForStaticMethod()
+    {
+        // TestClass::staticTestMethod();
+        // Get hover for staticTestMethod
+        $reference = $this->getReferenceLocations('TestClass::staticTestMethod()')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\npublic static function staticTestMethod()"),
+            'Do magna consequat veniam minim proident eiusmod incididunt aute proident.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForStaticProperty()
+    {
+        // echo TestClass::staticTestProperty;
+        // Get hover for staticTestProperty
+        $reference = $this->getReferenceLocations('TestClass::staticTestProperty')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\npublic static \$staticTestProperty;"),
+            'Lorem excepteur officia sit anim velit veniam enim.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForClassConstant()
+    {
+        // echo TestClass::TEST_CLASS_CONST;
+        // Get hover for TEST_CLASS_CONST
+        $reference = $this->getReferenceLocations('TestClass::TEST_CLASS_CONST')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\nconst TEST_CLASS_CONST = 123;"),
+            'Anim labore veniam consectetur laboris minim quis aute aute esse nulla ad.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForFunction()
+    {
+        // test_function();
+        // Get hover for test_function
+        $reference = $this->getReferenceLocations('test_function()')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\nfunction test_function()"),
+            'Officia aliquip adipisicing et nulla et laboris dolore labore.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForConstant()
+    {
+        // echo TEST_CONST;
+        // Get hover for TEST_CONST
+        $reference = $this->getReferenceLocations('TEST_CONST')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->end);
+        $this->assertEquals(new Hover([
+            new MarkedString('php', "<?php\nconst TEST_CONST = 123;"),
+            'Esse commodo excepteur pariatur Lorem est aute incididunt reprehenderit.'
+        ], $reference->range), $result);
+    }
+
+    public function testHoverForVariable()
     {
         // echo $var;
         // Get hover for $var
@@ -32,6 +116,21 @@ class HoverTest extends ServerTestCase
         $this->assertEquals(new Hover(
             [new MarkedString('php', "<?php\n\$var = 123;")],
             new Range(new Position(13, 5), new Position(13, 9))
+        ), $result);
+    }
+
+    public function testHoverForParam()
+    {
+        // echo $param;
+        // Get hover for $param
+        $uri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($uri), new Position(22, 11));
+        $this->assertEquals(new Hover(
+            [
+                new MarkedString('php', "<?php\n\TestNamespace\TestClass \$param"),
+                'Adipisicing non non cillum sint incididunt cillum enim mollit.'
+            ],
+            new Range(new Position(22, 9), new Position(22, 15))
         ), $result);
     }
 }

--- a/tests/Server/TextDocument/HoverTest.php
+++ b/tests/Server/TextDocument/HoverTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument;
+
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\Tests\Server\ServerTestCase;
+use LanguageServer\{Server, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentIdentifier, Position, Range, Hover, MarkedString};
+use function LanguageServer\pathToUri;
+
+class HoverTest extends ServerTestCase
+{
+    public function testHoverForClassLike()
+    {
+        // $obj = new TestClass();
+        // Get hover for TestClass
+        $reference = $this->getReferenceLocations('TestClass')[0];
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($reference->uri), $reference->range->start);
+        $this->assertEquals(new Hover([
+            'Pariatur ut laborum tempor voluptate consequat ea deserunt.',
+            new MarkedString('php', 'class TestClass implements \\TestInterface')
+        ], $reference->range), $result);
+    }
+
+    public function testHoverWithoutDocBlock()
+    {
+        // echo $var;
+        // Get hover for $var
+        $uri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
+        $result = $this->textDocument->hover(new TextDocumentIdentifier($uri), new Position(13, 7));
+        $this->assertEquals(new Hover(
+            [new MarkedString('php', '$var = 123;')],
+            new Range(new Position(13, 5), new Position(13, 9))
+        ), $result);
+    }
+}

--- a/tests/Server/TextDocument/References/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/References/GlobalFallbackTest.php
@@ -32,7 +32,7 @@ class GlobalFallbackTest extends ServerTestCase
     {
         // const TEST_CONST = 123;
         // Get references for TEST_CONST
-        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(4, 13));
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(9, 13));
         $this->assertEquals([new Location('global_fallback', new Range(new Position(6, 5), new Position(6, 15)))], $result);
     }
 
@@ -40,7 +40,7 @@ class GlobalFallbackTest extends ServerTestCase
     {
         // function test_function()
         // Get references for test_function
-        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(33, 16));
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(78, 16));
         $this->assertEquals([new Location('global_fallback', new Range(new Position(5, 0), new Position(5, 13)))], $result);
     }
 }

--- a/tests/Server/TextDocument/References/GlobalTest.php
+++ b/tests/Server/TextDocument/References/GlobalTest.php
@@ -77,11 +77,11 @@ class GlobalTest extends ServerTestCase
         // $var = 123;
         // Get definition for $var
         $uri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
-        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($uri), new Position(13, 7));
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($uri), new Position(12, 3));
         $this->assertEquals([
             new Location($uri, new Range(new Position(12, 0), new Position(12, 4))),
             new Location($uri, new Range(new Position(13, 5), new Position(13, 9))),
-            new Location($uri, new Range(new Position(20, 9), new Position(20, 13)))
+            new Location($uri, new Range(new Position(26, 9), new Position(26, 13)))
         ], $result);
     }
 
@@ -90,8 +90,8 @@ class GlobalTest extends ServerTestCase
         // function whatever(TestClass $param): TestClass
         // Get references for $param
         $uri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
-        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($uri), new Position(15, 32));
-        $this->assertEquals([new Location($uri, new Range(new Position(16, 9), new Position(16, 15)))], $result);
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($uri), new Position(21, 32));
+        $this->assertEquals([new Location($uri, new Range(new Position(22, 9), new Position(22, 15)))], $result);
     }
 
     public function testReferencesForFunctions()
@@ -100,7 +100,7 @@ class GlobalTest extends ServerTestCase
         // Get references for test_function
         $referencesUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
         $symbolsUri    = pathToUri(realpath(__DIR__ . '/../../../../fixtures/symbols.php'));
-        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($symbolsUri), new Position(33, 16));
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($symbolsUri), new Position(78, 16));
         $this->assertEquals([new Location($referencesUri, new Range(new Position(10, 0), new Position(10, 13)))], $result);
     }
 }


### PR DESCRIPTION
Closes #17 

Current implementation parses the docblock and displays the _summary_.

![image](https://cloud.githubusercontent.com/assets/10532611/19514022/5b6a20cc-95f2-11e6-8e32-0f22857b3def.png)

![image](https://cloud.githubusercontent.com/assets/10532611/19514047/7463314a-95f2-11e6-938f-94ff7c7d0c9c.png)

![image](https://cloud.githubusercontent.com/assets/10532611/19515098/51279b04-95f6-11e6-9cd0-5a1ca438d661.png)

# ToDo
- [x] Properties (parse `@var` tag)
- [x] Parameters (parse `@param` tag)
- [x] Variables
- [x] Return the signature of the declaration as a `php` `MarkedString` in addition to the documentation