### PR TITLE
References

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "bin": ["bin/php-language-server.php"],
     "require": {
         "php": ">=7.0",
-        "nikic/php-parser": "^3.0.0beta1",
+        "nikic/php-parser": "dev-master",
         "phpdocumentor/reflection-docblock": "^3.0",
         "sabre/event": "^4.0",
         "felixfbecker/advanced-json-rpc": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "bin": ["bin/php-language-server.php"],
     "require": {
         "php": ">=7.0",
-        "nikic/php-parser": "dev-master",
+        "nikic/php-parser": "dev-master#90834bff8eaf7b7f893253f312e73d8f532341ca",
         "phpdocumentor/reflection-docblock": "^3.0",
         "sabre/event": "^4.0",
         "felixfbecker/advanced-json-rpc": "^1.2",

--- a/fixtures/global_fallback.php
+++ b/fixtures/global_fallback.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GlobalFallback;
+
+// Should fall back to global_symbols.php
+test_function();
+echo TEST_CONST;
+
+// Should not fall back
+$obj = new TestClass();

--- a/fixtures/global_references.php
+++ b/fixtures/global_references.php
@@ -1,0 +1,24 @@
+<?php
+
+
+
+$obj = new TestClass();
+$obj->testMethod();
+echo $obj->testProperty;
+TestClass::staticTestMethod();
+echo TestClass::$staticTestProperty;
+echo TestClass::TEST_CLASS_CONST;
+test_function();
+
+$var = 123;
+echo $var;
+
+function whatever(TestClass $param): TestClass {
+    echo $param;
+}
+
+$fn = function() use ($var) {
+    echo $var;
+};
+
+echo TEST_CONST;

--- a/fixtures/global_symbols.php
+++ b/fixtures/global_symbols.php
@@ -1,0 +1,53 @@
+<?php
+
+
+
+const TEST_CONST = 123;
+
+class TestClass implements TestInterface
+{
+    const TEST_CLASS_CONST = 123;
+    public static $staticTestProperty;
+    public $testProperty;
+
+    public static function staticTestMethod()
+    {
+
+    }
+
+    public function testMethod($testParameter)
+    {
+        $testVariable = 123;
+    }
+}
+
+trait TestTrait
+{
+
+}
+
+interface TestInterface
+{
+
+}
+
+function test_function()
+{
+
+}
+
+new class {
+    const TEST_CLASS_CONST = 123;
+    public static $staticTestProperty;
+    public $testProperty;
+
+    public static function staticTestMethod()
+    {
+
+    }
+
+    public function testMethod($testParameter)
+    {
+        $testVariable = 123;
+    }
+};

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -105,6 +105,8 @@ class LanguageServer extends \AdvancedJsonRpc\Dispatcher
         $serverCapabilities->documentFormattingProvider = true;
         // Support "Go to definition"
         $serverCapabilities->definitionProvider = true;
+        // Support "Find all references"
+        $serverCapabilities->referencesProvider = true;
 
         return new InitializeResult($serverCapabilities);
     }

--- a/src/NodeVisitor/ReferencesCollector.php
+++ b/src/NodeVisitor/ReferencesCollector.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\NodeVisitor;
+
+use PhpParser\{NodeVisitorAbstract, Node};
+
+/**
+ * Collects references to classes, interfaces, traits, methods, properties and constants
+ * Depends on ReferencesAdder and NameResolver
+ */
+class ReferencesCollector extends NodeVisitorAbstract
+{
+    /**
+     * Map from fully qualified name (FQN) to array of nodes that reference the symbol
+     *
+     * @var Node[][]
+     */
+    public $references;
+
+    /**
+     * @var Node[]
+     */
+    private $definitions;
+
+    /**
+     * @param Node[] $definitions The definitions that references should be tracked for
+     */
+    public function __construct(array $definitions)
+    {
+        $this->definitions = $definitions;
+        $this->references = array_fill_keys(array_keys($definitions), []);
+    }
+
+    public function enterNode(Node $node)
+    {
+        // Check if the node references any global symbol
+        $fqn = $node->getAttribute('ownerDocument')->getReferencedFqn($node);
+        if ($fqn) {
+            $this->references[$fqn][] = $node;
+            // Static method calls, constant and property fetches also need to register a reference to the class
+            // A reference like TestNamespace\TestClass::myStaticMethod() registers a reference for
+            //  - TestNamespace\TestClass
+            //  - TestNamespace\TestClass::myStaticMethod()
+            if (
+                ($node instanceof Node\Expr\StaticCall
+                || $node instanceof Node\Expr\StaticPropertyFetch
+                || $node instanceof Node\Expr\ClassConstFetch)
+                && $node->class instanceof Node\Name
+            ) {
+                $this->references[(string)$node->class][] = $node->class;
+            }
+        }
+    }
+}

--- a/src/NodeVisitor/VariableReferencesCollector.php
+++ b/src/NodeVisitor/VariableReferencesCollector.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\NodeVisitor;
+
+use PhpParser\{NodeVisitorAbstract, Node, NodeTraverser};
+
+/**
+ * Collects all references to a variable
+ */
+class VariableReferencesCollector extends NodeVisitorAbstract
+{
+    /**
+     * Array of references to the variable
+     *
+     * @var Node\Expr\Variable[]
+     */
+    public $references = [];
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @param string $name The variable name
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Expr\Variable && $node->name === $this->name) {
+            $this->references[] = $node;
+        } else if ($node instanceof Node\FunctionLike) {
+            // If we meet a function node, dont traverse its statements, they are in another scope
+            // except it is a closure that has imported the variable through use
+            if ($node instanceof Node\Expr\Closure) {
+                foreach ($node->uses as $use) {
+                    if ($use->var === $this->name) {
+                        return;
+                    }
+                }
+            }
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+    }
+}

--- a/src/PhpDocument.php
+++ b/src/PhpDocument.php
@@ -412,7 +412,8 @@ class PhpDocument
             return null;
         }
         // If the node is a function or constant, it could be namespaced, but PHP falls back to global
-        // The NameResolver therefor does not resolve these to namespaced names
+        // The NameResolver therefor does not currently resolve these to namespaced names
+        // https://github.com/nikic/PHP-Parser/issues/236
         // http://php.net/manual/en/language.namespaces.fallback.php
         if ($parent instanceof Node\Expr\FuncCall || $parent instanceof Node\Expr\ConstFetch) {
             // Find and try with namespace
@@ -420,12 +421,7 @@ class PhpDocument
             while (isset($n)) {
                 $n = $n->getAttribute('parentNode');
                 if ($n instanceof Node\Stmt\Namespace_) {
-                    $namespacedName = (string)$n->name . '\\' . $name;
-                    // If the namespaced version is defined, return that
-                    // Otherwise fall back to global
-                    if ($this->project->isDefined($namespacedName)) {
-                        return $namespacedName;
-                    }
+                    return (string)$n->name . '\\' . $name;
                 }
             }
         }

--- a/src/PhpDocument.php
+++ b/src/PhpDocument.php
@@ -475,7 +475,7 @@ class PhpDocument
     {
         // Variables always stay in the boundary of the file and need to be searched inside their function scope
         // by traversing the AST
-        if ($node instanceof Node\Expr\Variable) {
+        if ($node instanceof Node\Expr\Variable || $node instanceof Node\Param) {
             if ($node->name instanceof Node\Expr) {
                 return null;
             }

--- a/src/Project.php
+++ b/src/Project.php
@@ -151,19 +151,19 @@ class Project
     }
 
     /**
-     * Adds a document as a referencee of a specific symbol
+     * Adds a document URI as a referencee of a specific symbol
      *
      * @param string $fqn The fully qualified name of the symbol
      * @return void
      */
-    public function addReferenceDocument(string $fqn, PhpDocument $document)
+    public function addReferenceUri(string $fqn, string $uri)
     {
         if (!isset($this->references[$fqn])) {
             $this->references[$fqn] = [];
         }
         // TODO: use DS\Set instead of searching array
-        if (array_search($document, $this->references[$fqn], true) === false) {
-            $this->references[$fqn][] = $document;
+        if (array_search($uri, $this->references[$fqn], true) === false) {
+            $this->references[$fqn][] = $uri;
         }
     }
 
@@ -175,7 +175,10 @@ class Project
      */
     public function getReferenceDocuments(string $fqn)
     {
-        return $this->references[$fqn] ?? [];
+        if (!isset($this->references[$fqn])) {
+            return [];
+        }
+        return array_map([$this, 'getDocument'], $this->references[$fqn]);
     }
 
     /**

--- a/src/Project.php
+++ b/src/Project.php
@@ -16,11 +16,18 @@ class Project
     private $documents = [];
 
     /**
-     * An associative array that maps fully qualified symbol names to document URIs
+     * An associative array that maps fully qualified symbol names to document URIs that define the symbol
      *
      * @var string[]
      */
     private $definitions = [];
+
+    /**
+     * An associative array that maps fully qualified symbol names to arrays of document URIs that reference the symbol
+     *
+     * @var PhpDocument[][]
+     */
+    private $references = [];
 
     /**
      * Instance of the PHP parser
@@ -141,6 +148,34 @@ class Project
     public function setDefinitionUri(string $fqn, string $uri)
     {
         $this->definitions[$fqn] = $uri;
+    }
+
+    /**
+     * Adds a document as a referencee of a specific symbol
+     *
+     * @param string $fqn The fully qualified name of the symbol
+     * @return void
+     */
+    public function addReferenceDocument(string $fqn, PhpDocument $document)
+    {
+        if (!isset($this->references[$fqn])) {
+            $this->references[$fqn] = [];
+        }
+        // TODO: use DS\Set instead of searching array
+        if (array_search($document, $this->references[$fqn], true) === false) {
+            $this->references[$fqn][] = $document;
+        }
+    }
+
+    /**
+     * Returns all documents that reference a symbol
+     *
+     * @param string $fqn The fully qualified name of the symbol
+     * @return PhpDocument[]
+     */
+    public function getReferenceDocuments(string $fqn)
+    {
+        return $this->references[$fqn] ?? [];
     }
 
     /**

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -110,28 +110,19 @@ class TextDocument
      * denoted by the given text document position.
      *
      * @param ReferenceContext $context
-     * @return Location[]|null
+     * @return Location[]
      */
-    public function references(ReferenceContext $context, TextDocumentIdentifier $textDocument, Position $position)
+    public function references(ReferenceContext $context, TextDocumentIdentifier $textDocument, Position $position): array
     {
         $document = $this->project->getDocument($textDocument->uri);
         $node = $document->getNodeAtPosition($position);
         if ($node === null) {
-            return null;
+            return [];
         }
-        $fqn = $document->getDefinedFqn($node);
-        if ($fqn === null) {
-            return null;
-        }
-        $refDocuments = $this->project->getReferenceDocuments($fqn);
+        $refs = $document->getReferencesByNode($node);
         $locations = [];
-        foreach ($refDocuments as $document) {
-            $refs = $document->getReferencesByFqn($fqn);
-            if ($refs !== null) {
-                foreach ($refs as $ref) {
-                    $locations[] = Location::fromNode($ref);
-                }
-            }
+        foreach ($refs as $ref) {
+            $locations[] = Location::fromNode($ref);
         }
         return $locations;
     }

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -31,7 +31,7 @@ class TextDocument
     /**
      * @var Project
      */
-    public $project;
+    private $project;
 
     public function __construct(Project $project, LanguageClient $client)
     {

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -35,7 +35,7 @@ class LanguageServerTest extends TestCase
                 'completionProvider' => null,
                 'signatureHelpProvider' => null,
                 'definitionProvider' => true,
-                'referencesProvider' => null,
+                'referencesProvider' => true,
                 'documentHighlightProvider' => null,
                 'workspaceSymbolProvider' => true,
                 'codeActionProvider' => null,

--- a/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument\Definition;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\{Server, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentIdentifier, Position};
+
+class GlobalFallbackTest extends TestCase
+{
+    /**
+     * @var Server\TextDocument
+     */
+    private $textDocument;
+
+    public function setUp()
+    {
+        $client = new LanguageClient(new MockProtocolStream());
+        $project = new Project($client);
+        $this->textDocument = new Server\TextDocument($project, $client);
+        $project->openDocument('global_fallback', file_get_contents(__DIR__ . '/../../../../fixtures/global_fallback.php'));
+        $project->openDocument('global_symbols', file_get_contents(__DIR__ . '/../../../../fixtures/global_symbols.php'));
+    }
+
+    public function testClassDoesNotFallback()
+    {
+        // $obj = new TestClass();
+        // Get definition for TestClass should not fall back to global
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('global_fallback'), new Position(9, 16));
+        $this->assertEquals([], $result);
+    }
+
+    public function testFallsBackForConstants()
+    {
+        // echo TEST_CONST;
+        // Get definition for TEST_CONST
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('global_fallback'), new Position(6, 10));
+        $this->assertEquals([
+            'uri' => 'global_symbols',
+            'range' => [
+                'start' => [
+                    'line' => 4,
+                    'character' => 6
+                ],
+                'end' => [
+                    'line' => 4,
+                    'character' => 22
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testFallsBackForFunctions()
+    {
+        // test_function();
+        // Get definition for test_function
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('global_fallback'), new Position(5, 6));
+        $this->assertEquals([
+            'uri' => 'global_symbols',
+            'range' => [
+                'start' => [
+                    'line' => 33,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 36,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+}

--- a/tests/Server/TextDocument/Definition/GlobalTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalTest.php
@@ -22,6 +22,10 @@ class GlobalTest extends TestCase
         $this->textDocument = new Server\TextDocument($project, $client);
         $project->openDocument('references', file_get_contents(__DIR__ . '/../../../../fixtures/global_references.php'));
         $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../../fixtures/global_symbols.php'));
+        // Load this to check that there are no conflicts
+        $project->openDocument('references_namespaced', file_get_contents(__DIR__ . '/../../../../fixtures/references.php'));
+        $project->openDocument('symbols_namespaced', file_get_contents(__DIR__ . '/../../../../fixtures/symbols.php'));
+        $project->openDocument('use', file_get_contents(__DIR__ . '/../../../../fixtures/use.php'));
     }
 
     public function testDefinitionFileBeginning() {

--- a/tests/Server/TextDocument/Definition/GlobalTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalTest.php
@@ -1,14 +1,14 @@
 <?php
 declare(strict_types = 1);
 
-namespace LanguageServer\Tests\Server\TextDocument;
+namespace LanguageServer\Tests\Server\TextDocument\Definition;
 
 use PHPUnit\Framework\TestCase;
 use LanguageServer\Tests\MockProtocolStream;
 use LanguageServer\{Server, LanguageClient, Project};
 use LanguageServer\Protocol\{TextDocumentIdentifier, Position};
 
-class DefinitionTest extends TestCase
+class GlobalTest extends TestCase
 {
     /**
      * @var Server\TextDocument
@@ -20,9 +20,8 @@ class DefinitionTest extends TestCase
         $client = new LanguageClient(new MockProtocolStream());
         $project = new Project($client);
         $this->textDocument = new Server\TextDocument($project, $client);
-        $project->openDocument('references', file_get_contents(__DIR__ . '/../../../fixtures/references.php'));
-        $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../fixtures/symbols.php'));
-        $project->openDocument('use', file_get_contents(__DIR__ . '/../../../fixtures/use.php'));
+        $project->openDocument('references', file_get_contents(__DIR__ . '/../../../../fixtures/global_references.php'));
+        $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../../fixtures/global_symbols.php'));
     }
 
     public function testDefinitionFileBeginning() {
@@ -51,46 +50,6 @@ class DefinitionTest extends TestCase
                 ],
                 'end' => [
                     'line' => 21,
-                    'character' => 1
-                ]
-            ]
-        ], json_decode(json_encode($result), true));
-    }
-
-    public function testDefinitionForClassLikeUseStatement()
-    {
-        // use TestNamespace\TestClass;
-        // Get definition for TestClass
-        $result = $this->textDocument->definition(new TextDocumentIdentifier('use'), new Position(4, 22));
-        $this->assertEquals([
-            'uri' => 'symbols',
-            'range' => [
-                'start' => [
-                    'line' => 6,
-                    'character' => 0
-                ],
-                'end' => [
-                    'line' => 21,
-                    'character' => 1
-                ]
-            ]
-        ], json_decode(json_encode($result), true));
-    }
-
-    public function testDefinitionForClassLikeGroupUseStatement()
-    {
-        // use TestNamespace\{TestTrait, TestInterface};
-        // Get definition for TestInterface
-        $result = $this->textDocument->definition(new TextDocumentIdentifier('use'), new Position(5, 37));
-        $this->assertEquals([
-            'uri' => 'symbols',
-            'range' => [
-                'start' => [
-                    'line' => 28,
-                    'character' => 0
-                ],
-                'end' => [
-                    'line' => 31,
                     'character' => 1
                 ]
             ]

--- a/tests/Server/TextDocument/Definition/NamespacedTest.php
+++ b/tests/Server/TextDocument/Definition/NamespacedTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use LanguageServer\Tests\MockProtocolStream;
 use LanguageServer\{Server, LanguageClient, Project};
 use LanguageServer\Protocol\{TextDocumentIdentifier, Position};
+use function LanguageServer\pathToUri;
 
 class NamespacedTest extends TestCase
 {
@@ -23,6 +24,9 @@ class NamespacedTest extends TestCase
         $project->openDocument('references', file_get_contents(__DIR__ . '/../../../../fixtures/references.php'));
         $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../../fixtures/symbols.php'));
         $project->openDocument('use', file_get_contents(__DIR__ . '/../../../../fixtures/use.php'));
+        // Load this to check that there are no conflicts
+        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php')));
+        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php')));
     }
 
     public function testDefinitionFileBeginning() {

--- a/tests/Server/TextDocument/Definition/NamespacedTest.php
+++ b/tests/Server/TextDocument/Definition/NamespacedTest.php
@@ -24,9 +24,6 @@ class NamespacedTest extends TestCase
         $project->openDocument('references', file_get_contents(__DIR__ . '/../../../../fixtures/references.php'));
         $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../../fixtures/symbols.php'));
         $project->openDocument('use', file_get_contents(__DIR__ . '/../../../../fixtures/use.php'));
-        // Load this to check that there are no conflicts
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php')));
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php')));
     }
 
     public function testDefinitionFileBeginning() {

--- a/tests/Server/TextDocument/Definition/NamespacedTest.php
+++ b/tests/Server/TextDocument/Definition/NamespacedTest.php
@@ -1,0 +1,358 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument\Definition;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\{Server, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentIdentifier, Position};
+
+class NamespacedTest extends TestCase
+{
+    /**
+     * @var Server\TextDocument
+     */
+    private $textDocument;
+
+    public function setUp()
+    {
+        $client = new LanguageClient(new MockProtocolStream());
+        $project = new Project($client);
+        $this->textDocument = new Server\TextDocument($project, $client);
+        $project->openDocument('references', file_get_contents(__DIR__ . '/../../../../fixtures/references.php'));
+        $project->openDocument('symbols', file_get_contents(__DIR__ . '/../../../../fixtures/symbols.php'));
+        $project->openDocument('use', file_get_contents(__DIR__ . '/../../../../fixtures/use.php'));
+    }
+
+    public function testDefinitionFileBeginning() {
+        // |<?php
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(0, 0));
+        $this->assertEquals([], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionEmptyResult() {
+        // namespace keyword
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(2, 4));
+        $this->assertEquals([], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForClassLike()
+    {
+        // $obj = new TestClass();
+        // Get definition for TestClass
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(4, 16));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 6,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 21,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForClassLikeUseStatement()
+    {
+        // use TestNamespace\TestClass;
+        // Get definition for TestClass
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('use'), new Position(4, 22));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 6,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 21,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForClassLikeGroupUseStatement()
+    {
+        // use TestNamespace\{TestTrait, TestInterface};
+        // Get definition for TestInterface
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('use'), new Position(5, 37));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 28,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 31,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForImplements()
+    {
+        // class TestClass implements TestInterface
+        // Get definition for TestInterface
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('symbols'), new Position(6, 33));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 28,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 31,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForClassConstants()
+    {
+        // echo TestClass::TEST_CLASS_CONST;
+        // Get definition for TEST_CLASS_CONST
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(9, 21));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 8,
+                    'character' => 10
+                ],
+                'end' => [
+                    'line' => 8,
+                    'character' => 32
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForConstants()
+    {
+        // echo TEST_CONST;
+        // Get definition for TEST_CONST
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(23, 9));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 4,
+                    'character' => 6
+                ],
+                'end' => [
+                    'line' => 4,
+                    'character' => 22
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForStaticMethods()
+    {
+        // TestClass::staticTestMethod();
+        // Get definition for staticTestMethod
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(7, 20));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 12,
+                    'character' => 4
+                ],
+                'end' => [
+                    'line' => 15,
+                    'character' => 5
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForStaticProperties()
+    {
+        // echo TestClass::$staticTestProperty;
+        // Get definition for staticTestProperty
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(8, 25));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 9,
+                    'character' => 18
+                ],
+                'end' => [
+                    'line' => 9,
+                    'character' => 37
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForMethods()
+    {
+        // $obj->testMethod();
+        // Get definition for testMethod
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(5, 11));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 17,
+                    'character' => 4
+                ],
+                'end' => [
+                    'line' => 20,
+                    'character' => 5
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForProperties()
+    {
+        // echo $obj->testProperty;
+        // Get definition for testProperty
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(6, 18));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 10,
+                    'character' => 11
+                ],
+                'end' => [
+                    'line' => 10,
+                    'character' => 24
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForVariables()
+    {
+        // echo $var;
+        // Get definition for $var
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(13, 7));
+        $this->assertEquals([
+            'uri' => 'references',
+            'range' => [
+                'start' => [
+                    'line' => 12,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 12,
+                    'character' => 10
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForParamTypeHints()
+    {
+        // function whatever(TestClass $param) {
+        // Get definition for TestClass
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(15, 23));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 6,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 21,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+    public function testDefinitionForReturnTypeHints()
+    {
+        // function whatever(TestClass $param) {
+        // Get definition for TestClass
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(15, 42));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 6,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 21,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForParams()
+    {
+        // echo $param;
+        // Get definition for $param
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(16, 13));
+        $this->assertEquals([
+            'uri' => 'references',
+            'range' => [
+                'start' => [
+                    'line' => 15,
+                    'character' => 18
+                ],
+                'end' => [
+                    'line' => 15,
+                    'character' => 34
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForUsedVariables()
+    {
+        // echo $var;
+        // Get definition for $var
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(20, 11));
+        $this->assertEquals([
+            'uri' => 'references',
+            'range' => [
+                'start' => [
+                    'line' => 19,
+                    'character' => 22
+                ],
+                'end' => [
+                    'line' => 19,
+                    'character' => 26
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionForFunctions()
+    {
+        // test_function();
+        // Get definition for test_function
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(10, 4));
+        $this->assertEquals([
+            'uri' => 'symbols',
+            'range' => [
+                'start' => [
+                    'line' => 33,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 36,
+                    'character' => 1
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+}

--- a/tests/Server/TextDocument/References/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/References/GlobalFallbackTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument\References;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\{Server, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentIdentifier, Position, ReferenceContext};
+
+class GlobalFallbackTest extends TestCase
+{
+    /**
+     * @var Server\TextDocument
+     */
+    private $textDocument;
+
+    public function setUp()
+    {
+        $client = new LanguageClient(new MockProtocolStream());
+        $project = new Project($client);
+        $this->textDocument = new Server\TextDocument($project, $client);
+        $project->openDocument('global_fallback', file_get_contents(__DIR__ . '/../../../../fixtures/global_fallback.php'));
+        $project->openDocument('global_symbols', file_get_contents(__DIR__ . '/../../../../fixtures/global_symbols.php'));
+    }
+
+    public function testClassDoesNotFallback()
+    {
+        // class TestClass implements TestInterface
+        // Get references for TestClass
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(6, 9));
+        $this->assertEquals([], $result);
+    }
+
+    public function testFallsBackForConstants()
+    {
+        // const TEST_CONST = 123;
+        // Get references for TEST_CONST
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(4, 13));
+        $this->assertEquals([
+            [
+                'uri' => 'global_fallback',
+                'range' => [
+                    'start' => [
+                        'line' => 6,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 6,
+                        'character' => 15
+                    ]
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testFallsBackForFunctions()
+    {
+        // function test_function()
+        // Get references for test_function
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier('global_symbols'), new Position(33, 16));
+        $this->assertEquals([
+            [
+                'uri' => 'global_fallback',
+                'range' => [
+                    'start' => [
+                        'line' => 5,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 5,
+                        'character' => 13
+                    ]
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+}

--- a/tests/Server/TextDocument/References/GlobalTest.php
+++ b/tests/Server/TextDocument/References/GlobalTest.php
@@ -9,7 +9,7 @@ use LanguageServer\{Server, LanguageClient, Project};
 use LanguageServer\Protocol\{TextDocumentIdentifier, Position, ReferenceContext};
 use function LanguageServer\pathToUri;
 
-class NamespacedTest extends TestCase
+class GlobalTest extends TestCase
 {
     /**
      * @var Server\TextDocument
@@ -18,22 +18,20 @@ class NamespacedTest extends TestCase
 
     private $symbolsUri;
     private $referencesUri;
-    private $useUri;
 
     public function setUp()
     {
         $client = new LanguageClient(new MockProtocolStream());
         $project = new Project($client);
         $this->textDocument = new Server\TextDocument($project, $client);
-        $this->symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/symbols.php'));
-        $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
-        $this->useUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/use.php'));
+        $this->symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php'));
+        $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php'));
         $project->loadDocument($this->referencesUri);
         $project->loadDocument($this->symbolsUri);
-        $project->loadDocument($this->useUri);
         // Load this to check that there are no conflicts
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php')));
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php')));
+        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/symbols.php')));
+        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php')));
+        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/use.php')));
     }
 
     public function testReferencesForClassLike()
@@ -123,20 +121,6 @@ class NamespacedTest extends TestCase
                     'end' => [
                         'line' => 15,
                         'character' => 46
-                    ]
-                ]
-            ],
-            // use TestNamespace\TestClass;
-            [
-                'uri' => $this->useUri,
-                'range' => [
-                    'start' => [
-                        'line' => 4,
-                        'character' => 4
-                    ],
-                    'end' => [
-                        'line' => 4,
-                        'character' => 27
                     ]
                 ]
             ]

--- a/tests/Server/TextDocument/References/GlobalTest.php
+++ b/tests/Server/TextDocument/References/GlobalTest.php
@@ -28,10 +28,6 @@ class GlobalTest extends TestCase
         $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php'));
         $project->loadDocument($this->referencesUri);
         $project->loadDocument($this->symbolsUri);
-        // Load this to check that there are no conflicts
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/symbols.php')));
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php')));
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/use.php')));
     }
 
     public function testReferencesForClassLike()

--- a/tests/Server/TextDocument/References/NamespacedTest.php
+++ b/tests/Server/TextDocument/References/NamespacedTest.php
@@ -186,20 +186,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForStaticMethods()
     {
-        $this->markTestIncomplete();
-        // TestClass::staticTestMethod();
-        // Get definition for staticTestMethod
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(7, 20));
+        // public static function staticTestMethod()
+        // Get references for staticTestMethod
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(12, 35));
         $this->assertEquals([
-            'uri' => $this->symbolsUri,
-            'range' => [
-                'start' => [
-                    'line' => 12,
-                    'character' => 4
-                ],
-                'end' => [
-                    'line' => 15,
-                    'character' => 4
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 7,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 7,
+                        'character' => 29
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));
@@ -207,20 +208,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForStaticProperties()
     {
-        $this->markTestIncomplete();
-        // echo TestClass::$staticTestProperty;
-        // Get definition for staticTestProperty
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(8, 25));
+        // public static $staticTestProperty;
+        // Get references for $staticTestProperty
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(9, 27));
         $this->assertEquals([
-            'uri' => $this->symbolsUri,
-            'range' => [
-                'start' => [
-                    'line' => 9,
-                    'character' => 18
-                ],
-                'end' => [
-                    'line' => 9,
-                    'character' => 36
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 8,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 8,
+                        'character' => 35
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));
@@ -228,20 +230,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForMethods()
     {
-        $this->markTestIncomplete();
-        // $obj->testMethod();
-        // Get definition for testMethod
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(5, 11));
+        // public function testMethod($testParameter)
+        // Get references for testMethod
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(17, 24));
         $this->assertEquals([
-            'uri' => $this->symbolsUri,
-            'range' => [
-                'start' => [
-                    'line' => 17,
-                    'character' => 4
-                ],
-                'end' => [
-                    'line' => 20,
-                    'character' => 4
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 5,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 5,
+                        'character' => 18
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));
@@ -249,20 +252,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForProperties()
     {
-        $this->markTestIncomplete();
-        // echo $obj->testProperty;
-        // Get definition for testProperty
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(6, 18));
+        // public $testProperty;
+        // Get references for testProperty
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(10, 15));
         $this->assertEquals([
-            'uri' => $this->symbolsUri,
-            'range' => [
-                'start' => [
-                    'line' => 10,
-                    'character' => 11
-                ],
-                'end' => [
-                    'line' => 10,
-                    'character' => 23
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 6,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 6,
+                        'character' => 23
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));
@@ -270,20 +274,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForVariables()
     {
-        $this->markTestIncomplete();
-        // echo $var;
+        // $var = 123;
         // Get definition for $var
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(13, 7));
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->referencesUri), new Position(13, 7));
         $this->assertEquals([
-            'uri' => $this->referencesUri,
-            'range' => [
-                'start' => [
-                    'line' => 12,
-                    'character' => 0
-                ],
-                'end' => [
-                    'line' => 12,
-                    'character' => 9
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 13,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 13,
+                        'character' => 8
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));

--- a/tests/Server/TextDocument/References/NamespacedTest.php
+++ b/tests/Server/TextDocument/References/NamespacedTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace LanguageServer\Tests\Server\TextDocument;
+namespace LanguageServer\Tests\Server\TextDocument\References;
 
 use PHPUnit\Framework\TestCase;
 use LanguageServer\Tests\MockProtocolStream;
@@ -9,7 +9,7 @@ use LanguageServer\{Server, LanguageClient, Project};
 use LanguageServer\Protocol\{TextDocumentIdentifier, Position, ReferenceContext};
 use function LanguageServer\pathToUri;
 
-class ReferencesTest extends TestCase
+class NamespacedTest extends TestCase
 {
     /**
      * @var Server\TextDocument
@@ -25,9 +25,9 @@ class ReferencesTest extends TestCase
         $client = new LanguageClient(new MockProtocolStream());
         $project = new Project($client);
         $this->textDocument = new Server\TextDocument($project, $client);
-        $this->symbolsUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/symbols.php'));
-        $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
-        $this->useUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/use.php'));
+        $this->symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/symbols.php'));
+        $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/references.php'));
+        $this->useUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/use.php'));
         $project->loadDocument($this->referencesUri, file_get_contents($this->referencesUri));
         $project->loadDocument($this->symbolsUri, file_get_contents($this->symbolsUri));
         $project->loadDocument($this->useUri, file_get_contents($this->useUri));

--- a/tests/Server/TextDocument/References/NamespacedTest.php
+++ b/tests/Server/TextDocument/References/NamespacedTest.php
@@ -282,12 +282,38 @@ class NamespacedTest extends TestCase
                 'uri' => $this->referencesUri,
                 'range' => [
                     'start' => [
+                        'line' => 12,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 12,
+                        'character' => 4
+                    ]
+                ]
+            ],
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
                         'line' => 13,
                         'character' => 5
                     ],
                     'end' => [
                         'line' => 13,
-                        'character' => 8
+                        'character' => 9
+                    ]
+                ]
+            ],
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 20,
+                        'character' => 9
+                    ],
+                    'end' => [
+                        'line' => 20,
+                        'character' => 13
                     ]
                 ]
             ]

--- a/tests/Server/TextDocument/References/NamespacedTest.php
+++ b/tests/Server/TextDocument/References/NamespacedTest.php
@@ -320,43 +320,23 @@ class NamespacedTest extends TestCase
         ], json_decode(json_encode($result), true));
     }
 
-    public function testReferencesForParams()
+    public function testReferencesForFunctionParams()
     {
-        $this->markTestIncomplete();
-        // echo $param;
-        // Get definition for $param
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(16, 13));
+        // function whatever(TestClass $param): TestClass
+        // Get references for $param
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->referencesUri), new Position(15, 32));
         $this->assertEquals([
-            'uri' => $this->referencesUri,
-            'range' => [
-                'start' => [
-                    'line' => 15,
-                    'character' => 18
-                ],
-                'end' => [
-                    'line' => 15,
-                    'character' => 33
-                ]
-            ]
-        ], json_decode(json_encode($result), true));
-    }
-
-    public function testReferencesForUsedVariables()
-    {
-        $this->markTestIncomplete();
-        // echo $var;
-        // Get definition for $var
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(20, 11));
-        $this->assertEquals([
-            'uri' => $this->referencesUri,
-            'range' => [
-                'start' => [
-                    'line' => 19,
-                    'character' => 22
-                ],
-                'end' => [
-                    'line' => 19,
-                    'character' => 25
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 16,
+                        'character' => 9
+                    ],
+                    'end' => [
+                        'line' => 16,
+                        'character' => 15
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));
@@ -364,20 +344,21 @@ class NamespacedTest extends TestCase
 
     public function testReferencesForFunctions()
     {
-        $this->markTestIncomplete();
-        // test_function();
-        // Get definition for test_function
-        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(10, 4));
+        // function test_function()
+        // Get references for test_function
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(33, 16));
         $this->assertEquals([
-            'uri' => $this->symbolsUri,
-            'range' => [
-                'start' => [
-                    'line' => 33,
-                    'character' => 0
-                ],
-                'end' => [
-                    'line' => 36,
-                    'character' => 0
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 10,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 10,
+                        'character' => 13
+                    ]
                 ]
             ]
         ], json_decode(json_encode($result), true));

--- a/tests/Server/TextDocument/References/NamespacedTest.php
+++ b/tests/Server/TextDocument/References/NamespacedTest.php
@@ -31,9 +31,6 @@ class NamespacedTest extends TestCase
         $project->loadDocument($this->referencesUri);
         $project->loadDocument($this->symbolsUri);
         $project->loadDocument($this->useUri);
-        // Load this to check that there are no conflicts
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php')));
-        $project->loadDocument(pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_references.php')));
     }
 
     public function testReferencesForClassLike()

--- a/tests/Server/TextDocument/ReferencesTest.php
+++ b/tests/Server/TextDocument/ReferencesTest.php
@@ -1,0 +1,354 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\{Server, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentIdentifier, Position, ReferenceContext};
+use function LanguageServer\pathToUri;
+
+class ReferencesTest extends TestCase
+{
+    /**
+     * @var Server\TextDocument
+     */
+    private $textDocument;
+
+    private $symbolsUri;
+    private $referencesUri;
+    private $useUri;
+
+    public function setUp()
+    {
+        $client = new LanguageClient(new MockProtocolStream());
+        $project = new Project($client);
+        $this->textDocument = new Server\TextDocument($project, $client);
+        $this->symbolsUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/symbols.php'));
+        $this->referencesUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
+        $this->useUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/use.php'));
+        $project->loadDocument($this->referencesUri, file_get_contents($this->referencesUri));
+        $project->loadDocument($this->symbolsUri, file_get_contents($this->symbolsUri));
+        $project->loadDocument($this->useUri, file_get_contents($this->useUri));
+    }
+
+    public function testReferencesForClassLike()
+    {
+        // class TestClass implements TestInterface
+        // Get references for TestClass
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(6, 9));
+        $this->assertEquals([
+            // $obj = new TestClass();
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 4,
+                        'character' => 11
+                    ],
+                    'end' => [
+                        'line' => 4,
+                        'character' => 20
+                    ]
+                ]
+            ],
+            // TestClass::staticTestMethod();
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 7,
+                        'character' => 0
+                    ],
+                    'end' => [
+                        'line' => 7,
+                        'character' => 9
+                    ]
+                ]
+            ],
+            // echo TestClass::$staticTestProperty;
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 8,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 8,
+                        'character' => 14
+                    ]
+                ]
+            ],
+            // TestClass::TEST_CLASS_CONST;
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 9,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 9,
+                        'character' => 14
+                    ]
+                ]
+            ],
+            // function whatever(TestClass $param)
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 15,
+                        'character' => 18
+                    ],
+                    'end' => [
+                        'line' => 15,
+                        'character' => 27
+                    ]
+                ]
+            ],
+            // function whatever(TestClass $param): TestClass
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 15,
+                        'character' => 37
+                    ],
+                    'end' => [
+                        'line' => 15,
+                        'character' => 46
+                    ]
+                ]
+            ],
+            // use TestNamespace\TestClass;
+            [
+                'uri' => $this->useUri,
+                'range' => [
+                    'start' => [
+                        'line' => 4,
+                        'character' => 4
+                    ],
+                    'end' => [
+                        'line' => 4,
+                        'character' => 27
+                    ]
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForClassConstants()
+    {
+        // const TEST_CLASS_CONST = 123;
+        // Get references for TEST_CLASS_CONST
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(8, 19));
+        $this->assertEquals([
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 9,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 9,
+                        'character' => 32
+                    ]
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForConstants()
+    {
+        // const TEST_CONST = 123;
+        // Get references for TEST_CONST
+        $result = $this->textDocument->references(new ReferenceContext, new TextDocumentIdentifier($this->symbolsUri), new Position(4, 13));
+        $this->assertEquals([
+            [
+                'uri' => $this->referencesUri,
+                'range' => [
+                    'start' => [
+                        'line' => 23,
+                        'character' => 5
+                    ],
+                    'end' => [
+                        'line' => 23,
+                        'character' => 15
+                    ]
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForStaticMethods()
+    {
+        $this->markTestIncomplete();
+        // TestClass::staticTestMethod();
+        // Get definition for staticTestMethod
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(7, 20));
+        $this->assertEquals([
+            'uri' => $this->symbolsUri,
+            'range' => [
+                'start' => [
+                    'line' => 12,
+                    'character' => 4
+                ],
+                'end' => [
+                    'line' => 15,
+                    'character' => 4
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForStaticProperties()
+    {
+        $this->markTestIncomplete();
+        // echo TestClass::$staticTestProperty;
+        // Get definition for staticTestProperty
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(8, 25));
+        $this->assertEquals([
+            'uri' => $this->symbolsUri,
+            'range' => [
+                'start' => [
+                    'line' => 9,
+                    'character' => 18
+                ],
+                'end' => [
+                    'line' => 9,
+                    'character' => 36
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForMethods()
+    {
+        $this->markTestIncomplete();
+        // $obj->testMethod();
+        // Get definition for testMethod
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(5, 11));
+        $this->assertEquals([
+            'uri' => $this->symbolsUri,
+            'range' => [
+                'start' => [
+                    'line' => 17,
+                    'character' => 4
+                ],
+                'end' => [
+                    'line' => 20,
+                    'character' => 4
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForProperties()
+    {
+        $this->markTestIncomplete();
+        // echo $obj->testProperty;
+        // Get definition for testProperty
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(6, 18));
+        $this->assertEquals([
+            'uri' => $this->symbolsUri,
+            'range' => [
+                'start' => [
+                    'line' => 10,
+                    'character' => 11
+                ],
+                'end' => [
+                    'line' => 10,
+                    'character' => 23
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForVariables()
+    {
+        $this->markTestIncomplete();
+        // echo $var;
+        // Get definition for $var
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(13, 7));
+        $this->assertEquals([
+            'uri' => $this->referencesUri,
+            'range' => [
+                'start' => [
+                    'line' => 12,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 12,
+                    'character' => 9
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForParams()
+    {
+        $this->markTestIncomplete();
+        // echo $param;
+        // Get definition for $param
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(16, 13));
+        $this->assertEquals([
+            'uri' => $this->referencesUri,
+            'range' => [
+                'start' => [
+                    'line' => 15,
+                    'character' => 18
+                ],
+                'end' => [
+                    'line' => 15,
+                    'character' => 33
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForUsedVariables()
+    {
+        $this->markTestIncomplete();
+        // echo $var;
+        // Get definition for $var
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(20, 11));
+        $this->assertEquals([
+            'uri' => $this->referencesUri,
+            'range' => [
+                'start' => [
+                    'line' => 19,
+                    'character' => 22
+                ],
+                'end' => [
+                    'line' => 19,
+                    'character' => 25
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+
+    public function testReferencesForFunctions()
+    {
+        $this->markTestIncomplete();
+        // test_function();
+        // Get definition for test_function
+        $result = $this->textDocument->definition(new TextDocumentIdentifier($this->referencesUri), new Position(10, 4));
+        $this->assertEquals([
+            'uri' => $this->symbolsUri,
+            'range' => [
+                'start' => [
+                    'line' => 33,
+                    'character' => 0
+                ],
+                'end' => [
+                    'line' => 36,
+                    'character' => 0
+                ]
+            ]
+        ], json_decode(json_encode($result), true));
+    }
+}


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/10532611/19220616/a286dd88-8e31-11e6-9fb1-28b974414ffd.png)

Adds support for `textDocument/references`. At index time in addition to definitions, also a map of FQN to array of referencing document URIs is kept.

Just like definition, it works very well for class-likes, functions and constants, but not so great for methods and properties where it is hard to infer the class. Variables and parameters also work surprisingly well.

# ToDo
- [x] Tests for other symbols than classes