### PR TITLE
Add stubs for PHP built-ins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,27 @@
         "sabre/event": "^4.0",
         "felixfbecker/advanced-json-rpc": "^1.2",
         "squizlabs/php_codesniffer" : "^2.7",
-        "symfony/debug": "^3.1"
+        "symfony/debug": "^3.1",
+        "JetBrains/phpstorm-stubs": "dev-master"
     },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "JetBrains/phpstorm-stubs",
+                "version": "dev-master",
+                "dist": {
+                    "url": "https://github.com/JetBrains/phpstorm-stubs/archive/master.zip",
+                    "type": "zip"
+                },
+                "source": {
+                    "url": "https://github.com/JetBrains/phpstorm-stubs",
+                    "type": "git",
+                    "reference": "master"
+                }
+            }
+        }
+    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
This is just a proposal on how the Jetbrains PHPStorm stubs could be added as a dependency.
We would then also need to include these in the indexing.

Since it would be pretty useless to reparse them everytime at startup it would be much nicer to parse them and then serialize the objects to disk so we only need to unserialize the structures. This is in alignment with #47 

The stubs are licensed under Apache2. Does anyone know if that is conflicting with ISC?
