### PR TITLE
Add Symfony ErrorHandler

### DIFF
--- a/bin/php-language-server.php
+++ b/bin/php-language-server.php
@@ -2,9 +2,9 @@
 
 use LanguageServer\{LanguageServer, ProtocolStreamReader, ProtocolStreamWriter};
 use Sabre\Event\Loop;
+use Symfony\Component\Debug\ErrorHandler;
 
 ini_set('memory_limit', '-1');
-cli_set_process_title('PHP Language Server');
 
 foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
     if (file_exists($file)) {
@@ -12,6 +12,10 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../autoload.php', __DI
         break;
     }
 }
+
+ErrorHandler::register();
+
+cli_set_process_title('PHP Language Server');
 
 if (count($argv) >= 3 && $argv[1] === '--tcp') {
     $address = $argv[2];

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "phpdocumentor/reflection-docblock": "^3.0",
         "sabre/event": "^4.0",
         "felixfbecker/advanced-json-rpc": "^1.2",
-        "squizlabs/php_codesniffer" : "^2.7"
+        "squizlabs/php_codesniffer" : "^2.7",
+        "symfony/debug": "^3.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Closes #5 
This will turn all notices/warnings like "Undefined index" into ErrorExceptions