### PR TITLE
Only hold content for open files in memory

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -153,7 +153,7 @@ class LanguageServer extends \AdvancedJsonRpc\Dispatcher
                 $shortName = substr($file, strlen($rootPath) + 1);
                 $this->client->window->logMessage(MessageType::INFO, "Parsing file $fileNum/$numTotalFiles: $shortName.");
 
-                $this->project->getDocument($uri)->updateContent(file_get_contents($file));
+                $this->project->getDocument($uri)->parse(file_get_contents($file));
 
                 Loop\setTimeout($processFile, 0);
             } else {

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -77,6 +77,18 @@ class TextDocument
         $this->project->getDocument($textDocument->uri)->updateContent($contentChanges[0]->text);
     }
 
+    /**
+     * The document close notification is sent from the client to the server when the document got closed in the client.
+     * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri the
+     * truth now exists on disk).
+     *
+     * @param \LanguageServer\Protocol\TextDocumentItem $textDocument The document that was closed
+     * @return void
+     */
+    public function didClose(TextDocumentIdentifier $textDocument)
+    {
+        $this->project->getDocument($textDocument->uri)->removeContent();
+    }
 
     /**
      * The document formatting request is sent from the server to the client to format a whole document.

--- a/tests/Server/TextDocument/DidCloseTest.php
+++ b/tests/Server/TextDocument/DidCloseTest.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\TextDocument;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\{Server, Client, LanguageClient, Project};
+use LanguageServer\Protocol\{TextDocumentItem, TextDocumentIdentifier};
+use Exception;
+
+class DidCloseTest extends TestCase
+{
+    public function test()
+    {
+        $client = new LanguageClient(new MockProtocolStream());
+        $project = new Project($client);
+        $textDocument = new Server\TextDocument($project, $client);
+        $phpDocument = $project->getDocument('whatever');
+        $phpDocument->updateContent('hello world');
+
+        $textDocumentItem = new TextDocumentItem();
+        $textDocumentItem->uri = 'whatever';
+        $textDocumentItem->languageId = 'php';
+        $textDocumentItem->version = 1;
+        $textDocumentItem->text = 'hello world';
+        $textDocument->didOpen($textDocumentItem);
+
+        $textDocument->didClose(new TextDocumentIdentifier($textDocumentItem->uri));
+
+        $this->expectException(Exception::class);
+        $phpDocument->getContent();
+    }
+}

--- a/tests/Server/TextDocument/FormattingTest.php
+++ b/tests/Server/TextDocument/FormattingTest.php
@@ -57,14 +57,4 @@ class FormattingTest extends TestCase
             'newText' => $expected
         ]], json_decode(json_encode($result), true));
     }
-
-    public function testFormattingInvalidUri()
-    {
-        $client = new LanguageClient(new MockProtocolStream());
-        $project = new Project($client);
-        $textDocument = new Server\TextDocument($project, $client);
-
-        $result = $textDocument->formatting(new TextDocumentIdentifier('whatever'), new FormattingOptions());
-        $this->assertSame([], $result);
-    }
 }


### PR DESCRIPTION
Addressing https://github.com/felixfbecker/php-language-server/issues/57#issuecomment-252572439

Content is only set on `didOpen`, and removed on `didClose`.
For indexing only the AST is kept.

It didn't reduce RAM usage unfortunately.