### PR TITLE
Return empty array instead of null for empty definitions result

### DIFF
--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -96,18 +96,18 @@ class TextDocument
      *
      * @param TextDocumentIdentifier $textDocument The text document
      * @param Position $position The position inside the text document
-     * @return Location|Location[]|null
+     * @return Location|Location[]
      */
     public function definition(TextDocumentIdentifier $textDocument, Position $position)
     {
         $document = $this->project->getDocument($textDocument->uri);
         $node = $document->getNodeAtPosition($position);
         if ($node === null) {
-            return null;
+            return array();
         }
         $def = $document->getDefinitionByNode($node);
         if ($def === null) {
-            return null;
+            return array();
         }
         return Location::fromNode($def);
     }

--- a/tests/Server/TextDocument/DefinitionTest.php
+++ b/tests/Server/TextDocument/DefinitionTest.php
@@ -25,6 +25,18 @@ class DefinitionTest extends TestCase
         $project->getDocument('use')->updateContent(file_get_contents(__DIR__ . '/../../../fixtures/use.php'));
     }
 
+    public function testDefinitionFileBeginning() {
+        // |<?php
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(0, 0));
+        $this->assertEquals([], json_decode(json_encode($result), true));
+    }
+
+    public function testDefinitionEmptyResult() {
+        // namespace keyword
+        $result = $this->textDocument->definition(new TextDocumentIdentifier('references'), new Position(2, 4));
+        $this->assertEquals([], json_decode(json_encode($result), true));
+    }
+
     public function testDefinitionForClassLike()
     {
         // $obj = new TestClass();


### PR DESCRIPTION
The result of the [Definition Request](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#goto-definition-request) is `Location|Location[]`. LSP says nothing about `null`. Thus, if no definition is found we should return an empty array instead of null.

Returning null breaks at least one client - the Typefox Java binding.