### PR TITLE
Cache index on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vscode
 .idea
 vendor/
+.phpls/
 composer.lock

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -181,6 +181,10 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     }
                 }
 
+                if ($fileNum % 1000 === 0) {
+                    $this->saveCache();
+                }
+
                 Loop\setTimeout($processFile, 0);
             } else {
                 $duration = (int)(microtime(true) - $startTime);

--- a/src/Project.php
+++ b/src/Project.php
@@ -161,6 +161,17 @@ class Project
     }
 
     /**
+     * Sets the SymbolInformation index
+     *
+     * @param SymbolInformation[] $symbols
+     * @return void
+     */
+    public function setSymbols(array $symbols)
+    {
+        $this->symbols = $symbols;
+    }
+
+    /**
      * Unsets the SymbolInformation for a specific symbol
      * and removes all references pointing to that symbol
      *
@@ -219,6 +230,28 @@ class Project
             return [];
         }
         return array_map([$this, 'getDocument'], $this->references[$fqn]);
+    }
+
+    /**
+     * Returns an associative array [string => string[]] that maps fully qualified symbol names
+     * to URIs of the document where the symbol is referenced
+     *
+     * @return string[][]
+     */
+    public function getReferenceUris()
+    {
+        return $this->references;
+    }
+
+    /**
+     * Sets the reference index
+     *
+     * @param string[][] $references an associative array [string => string[]] from FQN to URIs
+     * @return void
+     */
+    public function setReferenceUris(array $references)
+    {
+        $this->references = $references;
     }
 
     /**

--- a/src/Protocol/SymbolInformation.php
+++ b/src/Protocol/SymbolInformation.php
@@ -21,7 +21,7 @@ class SymbolInformation
     /**
      * The kind of this symbol.
      *
-     * @var number
+     * @var int
      */
     public $kind;
 


### PR DESCRIPTION
Closes #47

This is a very simple implementation of a disk cache. 
When index finished and on shutdown the definitions and references are saved to `.phpls/definitions.json` and `.phpls/references.json`.
On initialization, they are restored before beginning to reindex.
No fancy cache invalidation.
The result is when you once indexed a project, the second time you open it you can use all features instantly without having to wait for indexing to finish.

Magento:
```
[Info  - 02:07:26] Saving 203562 definitions to cache
[Info  - 02:07:26] Saving 323550 references to cache
```