### PR TITLE
Exit process if input or output stream is broken

### DIFF
--- a/src/ProtocolStreamReader.php
+++ b/src/ProtocolStreamReader.php
@@ -31,7 +31,7 @@ class ProtocolStreamReader implements ProtocolReader
         $this->input = $input;
         Loop\addReadStream($this->input, function() {
             if (feof($this->input)) {
-                throw new RuntimeException("Stream is closed.");
+                throw new RuntimeException('Stream is closed');
             }
 
             while (($c = fgetc($this->input)) !== false && $c !== '') {

--- a/src/ProtocolStreamReader.php
+++ b/src/ProtocolStreamReader.php
@@ -6,6 +6,7 @@ namespace LanguageServer;
 use LanguageServer\Protocol\Message;
 use AdvancedJsonRpc\Message as MessageBody;
 use Sabre\Event\Loop;
+use RuntimeException;
 
 abstract class ParsingMode
 {
@@ -30,7 +31,7 @@ class ProtocolStreamReader implements ProtocolReader
         $this->input = $input;
         Loop\addReadStream($this->input, function() {
             if (feof($this->input)) {
-                die;
+                throw new RuntimeException("Stream is closed.");
             }
 
             while (($c = fgetc($this->input)) !== false && $c !== '') {

--- a/src/ProtocolStreamReader.php
+++ b/src/ProtocolStreamReader.php
@@ -29,6 +29,10 @@ class ProtocolStreamReader implements ProtocolReader
     {
         $this->input = $input;
         Loop\addReadStream($this->input, function() {
+            if (feof($this->input)) {
+                die;
+            }
+
             while (($c = fgetc($this->input)) !== false && $c !== '') {
                 $this->buffer .= $c;
                 switch ($this->parsingMode) {

--- a/src/ProtocolStreamWriter.php
+++ b/src/ProtocolStreamWriter.php
@@ -31,16 +31,7 @@ class ProtocolStreamWriter implements ProtocolWriter
         $totalBytesWritten = 0;
 
         while ($totalBytesWritten < $msgSize) {
-            error_clear_last();
-            $bytesWritten = @fwrite($this->output, substr($data, $totalBytesWritten));
-            if ($bytesWritten === false) {
-                $error = error_get_last();
-                if ($error !== null) {
-                    throw new RuntimeException('Could not write message: ' . error_get_last()['message']);
-                } else {
-                    throw new RuntimeException('Could not write message');
-                }
-            }
+            $bytesWritten = fwrite($this->output, substr($data, $totalBytesWritten));
             $totalBytesWritten += $bytesWritten;
         }
     }

--- a/src/ProtocolStreamWriter.php
+++ b/src/ProtocolStreamWriter.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace LanguageServer;
 
 use LanguageServer\Protocol\Message;
-use RuntimeException;
 
 class ProtocolStreamWriter implements ProtocolWriter
 {


### PR DESCRIPTION
Fixes #106.

This is a simple patch that makes the language server to exit if the parent process died.

1. The custom error handling in the `ProtocolStreamWriter` is removed, so `fwrite`-ing to a closed stream results in throwing an exception. The process exits because of it.
2. An EOF check is added to the `ProtocolStreamReader`. If `stream_select()` activates the `ProtocolStreamReader` and there is only EOF in the stream then, most probably, the stream is already closed.

This PR can be improved, but for now I am pushing it like this to discuss if this is a good approach. It works for me at least. I tested different scenarios and in all of them if the VSCode process exits, the language server process exits too.

Possible ways to improve the new check in the `ProtocolStreamReader` would be:

1. Call `shutdown()` and `exit()` instead of just `die`.
2. if `feof()` returns `true` then do an additional check if the parent PID has really gone.