### PR TITLE
Make PHP shut up about socket notices

### DIFF
--- a/src/ProtocolStreamWriter.php
+++ b/src/ProtocolStreamWriter.php
@@ -30,7 +30,7 @@ class ProtocolStreamWriter implements ProtocolWriter
         $totalBytesWritten = 0;
 
         while ($totalBytesWritten < $msgSize) {
-            $bytesWritten = fwrite($this->output, substr($data, $totalBytesWritten));
+            $bytesWritten = @fwrite($this->output, substr($data, $totalBytesWritten));
             $totalBytesWritten += $bytesWritten;
         }
     }


### PR DESCRIPTION
@kaloyan-raev this doesn't solve the issue unfortunately. The language server now just exits, probably because of https://github.com/felixfbecker/php-language-server/blob/4dabd9a24014cc29fbb6dabb3587407a65bcbc46/src/ProtocolStreamReader.php#L33