### PR TITLE
Log only to STDERR

### DIFF
--- a/bin/php-language-server.php
+++ b/bin/php-language-server.php
@@ -3,6 +3,8 @@
 use LanguageServer\{LanguageServer, ProtocolStreamReader, ProtocolStreamWriter};
 use Sabre\Event\Loop;
 use Symfony\Component\Debug\ErrorHandler;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
 
 $options = getopt('', ['tcp::', 'memory-limit::']);
 
@@ -15,7 +17,11 @@ foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../autoload.php', __DI
     }
 }
 
-ErrorHandler::register();
+$logger = new Logger('Errors');
+$logger->pushHandler(new StreamHandler(STDERR));
+$errorHandler = new ErrorHandler;
+$errorHandler->setDefaultLogger($logger);
+ErrorHandler::register($errorHandler);
 
 @cli_set_process_title('PHP Language Server');
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "sabre/event": "^5.0",
         "felixfbecker/advanced-json-rpc": "^2.0",
         "squizlabs/php_codesniffer" : "^2.7",
-        "symfony/debug": "^3.1"
+        "symfony/debug": "^3.1",
+        "monolog/monolog": "^1.21"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -46,4 +46,19 @@ class LanguageServerTest extends TestCase
             ]
         ], $msg->body->result);
     }
+
+    public function testIndexing()
+    {
+        $input = new MockProtocolStream;
+        $output = new MockProtocolStream;
+        $output->on('message', function (Message $msg) {
+            var_dump($msg);
+        });
+        $server = new LanguageServer($input, $output);
+        $capabilities = new ClientCapabilities;
+        $capabilities->xcontent = true;
+        $capabilities->xglob = true;
+        $server->initialize(getmypid(), $capabilities, __DIR__);
+        \Sabre\Event\Loop\run();
+    }
 }


### PR DESCRIPTION
Closes #135 

Doesn't work currently:
```
PHP Fatal error:  Maximum function nesting level of '1000' reached, aborting! in C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php on line 60
PHP Stack trace:
PHP   1. Symfony\Component\Debug\ErrorHandler->handleException() C:\Users\felix\git\OpenSource\php-language-server\vendor\symfony\debug\ErrorHandler.php:0
PHP   2. Monolog\Logger->log() C:\Users\felix\git\OpenSource\php-language-server\vendor\symfony\debug\ErrorHandler.php:528
PHP   3. Monolog\Logger->addRecord() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Logger.php:517
PHP   4. Monolog\Handler\AbstractProcessingHandler->handle() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Logger.php:336
PHP   5. Monolog\Formatter\LineFormatter->format() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Handler\AbstractProcessingHandler.php:35
PHP   6. Monolog\Formatter\NormalizerFormatter->format() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\LineFormatter.php:68
PHP   7. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:43
PHP   8. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
PHP   9. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
PHP  10. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
PHP  11. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
PHP  12. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
PHP  13. Monolog\Formatter\NormalizerFormatter->normalize() C:\Users\felix\git\OpenSource\php-language-server\vendor\monolog\monolog\src\Monolog\Formatter\NormalizerFormatter.php:82
```
Don't know why.