### PR TITLE
Add size limit back

### DIFF
--- a/src/ContentTooLargeException.php
+++ b/src/ContentTooLargeException.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer;
+
+/**
+ * Thrown when the document content is not parsed because it exceeds the size limit
+ */
+class ContentTooLargeException extends \Exception
+{
+    /**
+     * The URI of the file that exceeded the limit
+     *
+     * @var string
+     */
+    public $uri;
+
+    /**
+     * The size of the file in bytes
+     *
+     * @var int
+     */
+    public $size;
+
+    /**
+     * The limit that was exceeded in bytes
+     *
+     * @var int
+     */
+    public $limit;
+
+    /**
+     * @param string     $uri      The URI of the file that exceeded the limit
+     * @param int        $size     The size of the file in bytes
+     * @param int        $limit    The limit that was exceeded in bytes
+     * @param \Throwable $previous The previous exception used for the exception chaining.
+     */
+    public function __construct(string $uri, int $size, int $limit, \Throwable $previous = null)
+    {
+        $this->uri = $uri;
+        $this->size = $size;
+        $this->limit = $limit;
+        parent::__construct("$uri exceeds size limit of $limit bytes ($size)", 0, $previous);
+    }
+}

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -183,11 +183,16 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Give LS to the chance to handle requests while indexing
                 yield timeout();
                 $this->client->window->logMessage(
-                    MessageType::INFO,
+                    MessageType::LOG,
                     "Parsing file $i/$count: {$textDocument->uri}"
                 );
                 try {
                     yield $this->project->loadDocument($textDocument->uri);
+                } catch (ContentTooLargeException $e) {
+                    $this->client->window->logMessage(
+                        MessageType::INFO,
+                        "Ignoring file {$textDocument->uri} because it exceeds size limit of {$e->limit} bytes ({$e->size})"
+                    );
                 } catch (Exception $e) {
                     $this->client->window->logMessage(
                         MessageType::ERROR,

--- a/src/Project.php
+++ b/src/Project.php
@@ -118,7 +118,6 @@ class Project
                 }
                 $content = file_get_contents($path);
             }
-            // Don't parse large files
             if (isset($this->documents[$uri])) {
                 $document = $this->documents[$uri];
                 $document->updateContent($content);

--- a/src/Project.php
+++ b/src/Project.php
@@ -103,17 +103,22 @@ class Project
     public function loadDocument(string $uri): Promise
     {
         return coroutine(function () use ($uri) {
+            $limit = 150000;
             if ($this->clientCapabilities->xcontentProvider) {
                 $content = (yield $this->client->textDocument->xcontent(new TextDocumentIdentifier($uri)))->text;
+                $size = strlen($content);
+                if ($size > $limit) {
+                    throw new ContentTooLargeException($uri, $size, $limit);
+                }
             } else {
-                $content = file_get_contents(uriToPath($uri));
+                $path = uriToPath($uri);
+                $size = filesize($path);
+                if ($size > $limit) {
+                    throw new ContentTooLargeException($uri, $size, $limit);
+                }
+                $content = file_get_contents($path);
             }
             // Don't parse large files
-            $size = strlen($content);
-            $limit = 150000;
-            if ($size > $limit) {
-                throw new ContentTooLargeException($uri, $size, $limit);
-            }
             if (isset($this->documents[$uri])) {
                 $document = $this->documents[$uri];
                 $document->updateContent($content);

--- a/src/Project.php
+++ b/src/Project.php
@@ -108,6 +108,12 @@ class Project
             } else {
                 $content = file_get_contents(uriToPath($uri));
             }
+            // Don't parse large files
+            $size = strlen($content);
+            $limit = 150000;
+            if ($size > $limit) {
+                throw new ContentTooLargeException($uri, $size, $limit);
+            }
             if (isset($this->documents[$uri])) {
                 $document = $this->documents[$uri];
                 $document->updateContent($content);


### PR DESCRIPTION
Closes #158 
@mniewrzal Not sure about the size limit. Previously we had 0.5MB, but that includes files like the (generated) PhpParser files take about a second to parse alone and is 0.13MB / 2751 loc.
A 0.1MB size limit ignores files like phpunit/tests/Framework/AssertTest.php (0.12MB, 4500 loc) which could be considered "normal".