### PR TITLE
Use custom error handler instead of Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "sabre/event": "^5.0",
         "felixfbecker/advanced-json-rpc": "^2.0",
         "squizlabs/php_codesniffer" : "^2.7",
-        "symfony/debug": "^3.1",
         "netresearch/jsonmapper": "^1.0",
         "webmozart/path-util": "^2.3",
         "webmozart/glob": "^4.1",


### PR DESCRIPTION
Symfony / Monolog turned out to be too much effort to configure.
Closes #137 #135 #152 