### PR TITLE
Implement global references protocol extension

### DIFF
--- a/src/Index/ProjectIndex.php
+++ b/src/Index/ProjectIndex.php
@@ -42,8 +42,8 @@ class ProjectIndex extends AbstractAggregateIndex
      */
     public function getIndexForUri(string $uri): Index
     {
-        if (preg_match('/\/vendor\/(\w+\/\w+)\//', $uri, $matches)) {
-            $packageName = $matches[0];
+        if (preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $uri, $matches)) {
+            $packageName = $matches[1];
             return $this->dependenciesIndex->getDependencyIndex($packageName);
         }
         return $this->sourceIndex;

--- a/src/Protocol/DependencyReference.php
+++ b/src/Protocol/DependencyReference.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+class DependencyReference
+{
+    /**
+     * @var mixed
+     */
+    public $hints;
+
+    /**
+     * @var object
+     */
+    public $attributes;
+
+    /**
+     * @param object $attributes
+     * @param mixed  $hints
+     */
+    public function __construct($attributes = null, $hints = null)
+    {
+        $this->attributes = $attributes ?? new \stdClass;
+        $this->hints = $hints;
+    }
+}

--- a/src/Protocol/ReferenceInformation.php
+++ b/src/Protocol/ReferenceInformation.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+/**
+ * Metadata about the symbol that can be used to identify or locate its
+ * definition.
+ */
+class ReferenceInformation
+{
+    /**
+     * The location in the workspace where the `symbol` is referenced.
+     *
+     * @var Location
+     */
+    public $reference;
+
+    /**
+     * Metadata about the symbol that can be used to identify or locate its
+     * definition.
+     *
+     * @var SymbolDescriptor
+     */
+    public $symbol;
+
+    /**
+     * @param Location         $reference The location in the workspace where the `symbol` is referenced.
+     * @param SymbolDescriptor $symbol    Metadata about the symbol that can be used to identify or locate its definition.
+     */
+    public function __construct(Location $reference = null, SymbolDescriptor $symbol = null)
+    {
+        $this->reference = $reference;
+        $this->symbol = $symbol;
+    }
+}

--- a/src/Protocol/ServerCapabilities.php
+++ b/src/Protocol/ServerCapabilities.php
@@ -108,4 +108,25 @@ class ServerCapabilities
      * @var bool|null
      */
     public $renameProvider;
+
+    /**
+     * The server provides workspace references exporting support.
+     *
+     * @var bool|null
+     */
+    public $xworkspaceReferencesProvider;
+
+    /**
+     * The server provides extended text document definition support.
+     *
+     * @var bool|null
+     */
+    public $xdefinitionProvider;
+
+    /**
+     * The server provides workspace dependencies support.
+     *
+     * @var bool|null
+     */
+    public $dependenciesProvider;
 }

--- a/src/Protocol/SymbolDescriptor.php
+++ b/src/Protocol/SymbolDescriptor.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+class SymbolDescriptor extends SymbolInformation
+{
+    /**
+     * The fully qualified structural element name, a globally unique identifier for the symbol.
+     *
+     * @var string
+     */
+    public $fqsen;
+
+    /**
+     * A package from the composer.lock file or the contents of the composer.json
+     * Example: https://github.com/composer/composer/blob/master/composer.lock#L10
+     * Available fields may differ
+     *
+     * @var object|null
+     */
+    public $package;
+
+    /**
+     * @param string $fqsen   The fully qualified structural element name, a globally unique identifier for the symbol.
+     * @param object $package A package from the composer.lock file or the contents of the composer.json
+     */
+    public function __construct(string $fqsen = null, $package = null)
+    {
+        $this->fqsen = $fqsen;
+        $this->package = $package;
+    }
+}

--- a/src/Protocol/SymbolLocationInformation.php
+++ b/src/Protocol/SymbolLocationInformation.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+class SymbolLocationInformation
+{
+    /**
+     * The location where the symbol is defined, if any.
+     *
+     * @var Location|null
+     */
+    public $location;
+
+    /**
+     * Metadata about the symbol that can be used to identify or locate its
+     * definition.
+     *
+     * @var SymbolDescriptor
+     */
+    public $symbol;
+
+    /**
+     * @param SymbolDescriptor $symbol   The location where the symbol is defined, if any
+     * @param Location         $location Metadata about the symbol that can be used to identify or locate its definition
+     */
+    public function __construct(SymbolDescriptor $symbol = null, Location $location = null)
+    {
+        $this->symbol = $symbol;
+        $this->location = $location;
+    }
+}

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -3,22 +3,17 @@ declare(strict_types = 1);
 
 namespace LanguageServer\Server;
 
-use LanguageServer\{LanguageClient, Project};
-use LanguageServer\Index\ProjectIndex;
-use LanguageServer\Protocol\SymbolInformation;
+use LanguageServer\{LanguageClient, Project, PhpDocumentLoader};
+use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
+use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInformation, DependencyReference, Location};
+use Sabre\Event\Promise;
+use function Sabre\Event\coroutine;
 
 /**
  * Provides method handlers for all workspace/* methods
  */
 class Workspace
 {
-    /**
-     * The lanugage client object to call methods on the client
-     *
-     * @var \LanguageServer\LanguageClient
-     */
-    private $client;
-
     /**
      * The symbol index for the workspace
      *
@@ -27,12 +22,39 @@ class Workspace
     private $index;
 
     /**
-     * @param ProjectIndex $index Index that is searched on a workspace/symbol request
+     * @var DependenciesIndex
      */
-    public function __construct(ProjectIndex $index, LanguageClient $client)
+    private $dependenciesIndex;
+
+    /**
+     * @var Index
+     */
+    private $sourceIndex;
+
+    /**
+     * @var \stdClass
+     */
+    public $composerLock;
+
+    /**
+     * @var PhpDocumentLoader
+     */
+    public $documentLoader;
+
+    /**
+     * @param ProjectIndex      $index             Index that is searched on a workspace/symbol request
+     * @param DependenciesIndex $dependenciesIndex Index that is used on a workspace/xreferences request
+     * @param DependenciesIndex $sourceIndex       Index that is used on a workspace/xreferences request
+     * @param \stdClass         $composerLock      The parsed composer.lock of the project, if any
+     * @param PhpDocumentLoader $documentLoader    PhpDocumentLoader instance to load documents
+     */
+    public function __construct(ProjectIndex $index, DependenciesIndex $dependenciesIndex, Index $sourceIndex, \stdClass $composerLock = null, PhpDocumentLoader $documentLoader)
     {
+        $this->sourceIndex = $sourceIndex;
         $this->index = $index;
-        $this->client = $client;
+        $this->dependenciesIndex = $dependenciesIndex;
+        $this->composerLock = $composerLock;
+        $this->documentLoader = $documentLoader;
     }
 
     /**
@@ -50,5 +72,91 @@ class Workspace
             }
         }
         return $symbols;
+    }
+
+    /**
+     * The workspace references request is sent from the client to the server to locate project-wide references to a symbol given its description / metadata.
+     *
+     * @param SymbolDescriptor $query Partial metadata about the symbol that is being searched for.
+     * @param string[]         $files An optional list of files to restrict the search to.
+     * @return ReferenceInformation[]
+     */
+    public function xreferences($query, array $files = null): Promise
+    {
+        return coroutine(function () use ($query, $files) {
+            if ($this->composerLock === null) {
+                return [];
+            }
+            /** Map from URI to array of referenced FQNs in dependencies */
+            $refs = [];
+            // Get all references TO dependencies
+            $fqns = isset($query->fqsen) ? [$query->fqsen] : array_values($this->dependenciesIndex->getDefinitions());
+            foreach ($fqns as $fqn) {
+                foreach ($this->sourceIndex->getReferenceUris($fqn) as $uri) {
+                    if (!isset($refs[$uri])) {
+                        $refs[$uri] = [];
+                    }
+                    if (array_search($uri, $refs[$uri]) === false) {
+                        $refs[$uri][] = $fqn;
+                    }
+                }
+            }
+            $refInfos = [];
+            foreach ($refs as $uri => $fqns) {
+                foreach ($fqns as $fqn) {
+                    $def = $this->dependenciesIndex->getDefinition($fqn);
+                    $symbol = new SymbolDescriptor;
+                    $symbol->fqsen = $fqn;
+                    foreach (get_object_vars($def->symbolInformation) as $prop => $val) {
+                        $symbol->$prop = $val;
+                    }
+                    // Find out package name
+                    preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $def->symbolInformation->location->uri, $matches);
+                    $packageName = $matches[1];
+                    foreach ($this->composerLock->packages as $package) {
+                        if ($package->name === $packageName) {
+                            $symbol->package = $package;
+                            break;
+                        }
+                    }
+                    // If there was no FQSEN provided, check if query attributes match
+                    if (!isset($query->fqsen)) {
+                        $matches = true;
+                        foreach (get_object_vars($query) as $prop => $val) {
+                            if ($query->$prop != $symbol->$prop) {
+                                $matches = false;
+                                break;
+                            }
+                        }
+                        if (!$matches) {
+                            continue;
+                        }
+                    }
+                    $doc = yield $this->documentLoader->getOrLoad($uri);
+                    foreach ($doc->getReferenceNodesByFqn($fqn) as $node) {
+                        $refInfo = new ReferenceInformation;
+                        $refInfo->reference = Location::fromNode($node);
+                        $refInfo->symbol = $symbol;
+                        $refInfos[] = $refInfo;
+                    }
+                }
+            }
+            return $refInfos;
+        });
+    }
+
+    /**
+     * @return DependencyReference[]
+     */
+    public function xdependencies(): array
+    {
+        if ($this->composerLock === null) {
+            return [];
+        }
+        $dependencyReferences = [];
+        foreach ($this->composerLock->packages as $package) {
+            $dependencyReferences[] = new DependencyReference($package);
+        }
+        return $dependencyReferences;
     }
 }

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -41,6 +41,9 @@ class LanguageServerTest extends TestCase
         $serverCapabilities->completionProvider = new CompletionOptions;
         $serverCapabilities->completionProvider->resolveProvider = false;
         $serverCapabilities->completionProvider->triggerCharacters = ['$', '>'];
+        $serverCapabilities->xworkspaceReferencesProvider = true;
+        $serverCapabilities->xdefinitionProvider = true;
+        $serverCapabilities->xdependenciesProvider = true;
 
         $this->assertEquals(new InitializeResult($serverCapabilities), $result);
     }

--- a/tests/Server/ServerTestCase.php
+++ b/tests/Server/ServerTestCase.php
@@ -45,13 +45,15 @@ abstract class ServerTestCase extends TestCase
 
     public function setUp()
     {
-        $projectIndex = new ProjectIndex(new Index, new DependenciesIndex);
+        $sourceIndex       = new Index;
+        $dependenciesIndex = new DependenciesIndex;
+        $projectIndex      = new ProjectIndex($sourceIndex, $dependenciesIndex);
 
         $definitionResolver   = new DefinitionResolver($projectIndex);
         $client               = new LanguageClient(new MockProtocolStream, new MockProtocolStream);
         $this->documentLoader = new PhpDocumentLoader(new FileSystemContentRetriever, $projectIndex, $definitionResolver);
         $this->textDocument   = new Server\TextDocument($this->documentLoader, $definitionResolver, $client, $projectIndex);
-        $this->workspace      = new Server\Workspace($projectIndex, $client);
+        $this->workspace      = new Server\Workspace($projectIndex, $dependenciesIndex, $sourceIndex, null, $this->documentLoader);
 
         $globalSymbolsUri    = pathToUri(realpath(__DIR__ . '/../../fixtures/global_symbols.php'));
         $globalReferencesUri = pathToUri(realpath(__DIR__ . '/../../fixtures/global_references.php'));


### PR DESCRIPTION
This implements the [global references protocol extension](https://github.com/sourcegraph/language-server-protocol/blob/master/extension-workspace-references.md).
The extension allows the language server to return information about dependencies, return package information when doing jump to definiton into dependencies and get all references to external symbols.

One important change is that indexing is now part of `initialize`, so no request may be answered until indexing finished. This is because otherwise the completeness of responses can never be guaranteed and there is no way to indicate the "actual" ready state of the language server.