### PR TITLE
Make Index an EventEmitter

### DIFF
--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -58,6 +58,8 @@ class ComposerScripts
                 $document = new PhpDocument($uri, $content, $index, $parser, $docBlockFactory, $definitionResolver);
             }
 
+            $index->setComplete();
+
             echo "Saving Index\n";
 
             $index->save();

--- a/src/Index/AbstractAggregateIndex.php
+++ b/src/Index/AbstractAggregateIndex.php
@@ -4,15 +4,60 @@ declare(strict_types = 1);
 namespace LanguageServer\Index;
 
 use LanguageServer\Definition;
+use Sabre\Event\EmitterTrait;
 
 abstract class AbstractAggregateIndex implements ReadableIndex
 {
+    use EmitterTrait;
+
     /**
      * Returns all indexes managed by the aggregate index
      *
      * @return ReadableIndex[]
      */
     abstract protected function getIndexes(): array;
+
+    public function __construct()
+    {
+        foreach ($this->getIndexes() as $index) {
+            $index->on('complete', function () {
+                if ($this->isComplete()) {
+                    $this->emit('complete');
+                }
+            });
+            $index->on('definition-added', function () {
+                $this->emit('definition-added');
+            });
+        }
+    }
+
+    /**
+     * Marks this index as complete
+     *
+     * @return void
+     */
+    public function setComplete()
+    {
+        foreach ($this->getIndexes() as $index) {
+            $index->setComplete();
+        }
+        $this->emit('complete');
+    }
+
+    /**
+     * Returns true if this index is complete
+     *
+     * @return bool
+     */
+    public function isComplete(): bool
+    {
+        foreach ($this->getIndexes() as $index) {
+            if (!$index->isComplete()) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /**
      * Returns an associative array [string => Definition] that maps fully qualified symbol names

--- a/src/Index/AbstractAggregateIndex.php
+++ b/src/Index/AbstractAggregateIndex.php
@@ -41,7 +41,6 @@ abstract class AbstractAggregateIndex implements ReadableIndex
         foreach ($this->getIndexes() as $index) {
             $index->setComplete();
         }
-        $this->emit('complete');
     }
 
     /**

--- a/src/Index/AbstractAggregateIndex.php
+++ b/src/Index/AbstractAggregateIndex.php
@@ -20,15 +20,28 @@ abstract class AbstractAggregateIndex implements ReadableIndex
     public function __construct()
     {
         foreach ($this->getIndexes() as $index) {
-            $index->on('complete', function () {
-                if ($this->isComplete()) {
-                    $this->emit('complete');
-                }
-            });
-            $index->on('definition-added', function () {
-                $this->emit('definition-added');
-            });
+            $this->registerIndex($index);
         }
+    }
+
+    /**
+     * @param ReadableIndex $index
+     */
+    protected function registerIndex(ReadableIndex $index)
+    {
+        $index->on('complete', function () {
+            if ($this->isComplete()) {
+                $this->emit('complete');
+            }
+        });
+        $index->on('static-complete', function () {
+            if ($this->isStaticComplete()) {
+                $this->emit('static-complete');
+            }
+        });
+        $index->on('definition-added', function () {
+            $this->emit('definition-added');
+        });
     }
 
     /**
@@ -44,6 +57,18 @@ abstract class AbstractAggregateIndex implements ReadableIndex
     }
 
     /**
+     * Marks this index as complete for static definitions and references
+     *
+     * @return void
+     */
+    public function setStaticComplete()
+    {
+        foreach ($this->getIndexes() as $index) {
+            $index->setStaticComplete();
+        }
+    }
+
+    /**
      * Returns true if this index is complete
      *
      * @return bool
@@ -52,6 +77,21 @@ abstract class AbstractAggregateIndex implements ReadableIndex
     {
         foreach ($this->getIndexes() as $index) {
             if (!$index->isComplete()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns true if this index is complete for static definitions or references
+     *
+     * @return bool
+     */
+    public function isStaticComplete(): bool
+    {
+        foreach ($this->getIndexes() as $index) {
+            if (!$index->isStaticComplete()) {
                 return false;
             }
         }

--- a/src/Index/DependenciesIndex.php
+++ b/src/Index/DependenciesIndex.php
@@ -27,7 +27,9 @@ class DependenciesIndex extends AbstractAggregateIndex
     public function getDependencyIndex(string $packageName): Index
     {
         if (!isset($this->indexes[$packageName])) {
-            $this->indexes[$packageName] = new Index;
+            $index = new Index;
+            $this->indexes[$packageName] = $index;
+            $this->registerIndex($index);
         }
         return $this->indexes[$packageName];
     }

--- a/src/Index/GlobalIndex.php
+++ b/src/Index/GlobalIndex.php
@@ -26,6 +26,7 @@ class GlobalIndex extends AbstractAggregateIndex
     {
         $this->stubsIndex = $stubsIndex;
         $this->projectIndex = $projectIndex;
+        parent::__construct();
     }
 
     /**

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -45,6 +45,9 @@ class Index implements ReadableIndex
      */
     public function setComplete()
     {
+        if (!$this->isStaticComplete()) {
+            $this->setStaticComplete();
+        }
         $this->complete = true;
         $this->emit('complete');
     }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -34,6 +34,11 @@ class Index implements ReadableIndex
     private $complete = false;
 
     /**
+     * @var bool
+     */
+    private $staticComplete = false;
+
+    /**
      * Marks this index as complete
      *
      * @return void
@@ -45,6 +50,17 @@ class Index implements ReadableIndex
     }
 
     /**
+     * Marks this index as complete for static definitions and references
+     *
+     * @return void
+     */
+    public function setStaticComplete()
+    {
+        $this->complete = true;
+        $this->emit('static-complete');
+    }
+
+    /**
      * Returns true if this index is complete
      *
      * @return bool
@@ -52,6 +68,16 @@ class Index implements ReadableIndex
     public function isComplete(): bool
     {
         return $this->complete;
+    }
+
+    /**
+     * Returns true if this index is complete
+     *
+     * @return bool
+     */
+    public function isStaticComplete(): bool
+    {
+        return $this->staticComplete;
     }
 
     /**

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace LanguageServer\Index;
 
 use LanguageServer\Definition;
+use Sabre\Event\EmitterTrait;
 
 /**
  * Represents the index of a project or dependency
@@ -11,6 +12,8 @@ use LanguageServer\Definition;
  */
 class Index implements ReadableIndex
 {
+    use EmitterTrait;
+
     /**
      * An associative array that maps fully qualified symbol names to Definitions
      *
@@ -24,6 +27,32 @@ class Index implements ReadableIndex
      * @var string[][]
      */
     private $references = [];
+
+    /**
+     * @var bool
+     */
+    private $complete = false;
+
+    /**
+     * Marks this index as complete
+     *
+     * @return void
+     */
+    public function setComplete()
+    {
+        $this->complete = true;
+        $this->emit('complete');
+    }
+
+    /**
+     * Returns true if this index is complete
+     *
+     * @return bool
+     */
+    public function isComplete(): bool
+    {
+        return $this->complete;
+    }
 
     /**
      * Returns an associative array [string => Definition] that maps fully qualified symbol names
@@ -65,6 +94,7 @@ class Index implements ReadableIndex
     public function setDefinition(string $fqn, Definition $definition)
     {
         $this->definitions[$fqn] = $definition;
+        $this->emit('definition-added');
     }
 
     /**

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -56,7 +56,7 @@ class Index implements ReadableIndex
      */
     public function setStaticComplete()
     {
-        $this->complete = true;
+        $this->staticComplete = true;
         $this->emit('static-complete');
     }
 

--- a/src/Index/ProjectIndex.php
+++ b/src/Index/ProjectIndex.php
@@ -26,6 +26,7 @@ class ProjectIndex extends AbstractAggregateIndex
     {
         $this->sourceIndex = $sourceIndex;
         $this->dependenciesIndex = $dependenciesIndex;
+        parent::__construct();
     }
 
     /**

--- a/src/Index/ReadableIndex.php
+++ b/src/Index/ReadableIndex.php
@@ -4,12 +4,23 @@ declare(strict_types = 1);
 namespace LanguageServer\Index;
 
 use LanguageServer\Definition;
+use Sabre\Event\EmitterInterface;
 
 /**
  * The ReadableIndex interface provides methods to lookup definitions and references
+ *
+ * @event definition-added Emitted when a definition was added
+ * @event complete         Emitted when the index is complete
  */
-interface ReadableIndex
+interface ReadableIndex extends EmitterInterface
 {
+    /**
+     * Returns true if this index is complete
+     *
+     * @return bool
+     */
+    public function isComplete(): bool;
+
     /**
      * Returns an associative array [string => Definition] that maps fully qualified symbol names
      * to Definitions

--- a/src/Index/ReadableIndex.php
+++ b/src/Index/ReadableIndex.php
@@ -10,6 +10,7 @@ use Sabre\Event\EmitterInterface;
  * The ReadableIndex interface provides methods to lookup definitions and references
  *
  * @event definition-added Emitted when a definition was added
+ * @event static-complete  Emitted when definitions and static references are complete
  * @event complete         Emitted when the index is complete
  */
 interface ReadableIndex extends EmitterInterface
@@ -20,6 +21,13 @@ interface ReadableIndex extends EmitterInterface
      * @return bool
      */
     public function isComplete(): bool;
+
+    /**
+     * Returns true if definitions and static references are complete
+     *
+     * @return bool
+     */
+    public function isStaticComplete(): bool;
 
     /**
      * Returns an associative array [string => Definition] that maps fully qualified symbol names

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -295,7 +295,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @param string $rootPath
      */
-    protected function beforeIndex(string $rootPath) {}
+    protected function beforeIndex(string $rootPath)
+    {
+    }
 
     /**
      * Will read and parse the passed source files in the project and add them to the appropiate indexes

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -316,8 +316,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
             $startTime = microtime(true);
 
-            foreach (['Collecting definitions and static references', 'Collecting dynamic references'] as $run) {
-                $this->client->window->logMessage(MessageType::INFO, $run);
+            foreach (['Collecting definitions and static references', 'Collecting dynamic references'] as $run => $text) {
+                $this->client->window->logMessage(MessageType::INFO, $text);
                 foreach ($uris as $i => $uri) {
                     if ($this->documentLoader->isOpen($uri)) {
                         continue;
@@ -346,7 +346,11 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                         );
                     }
                 }
-                $this->projectIndex->setComplete();
+                if ($run === 0) {
+                    $this->projectIndex->setStaticComplete();
+                } else {
+                    $this->projectIndex->setComplete();
+                }
                 $duration = (int)(microtime(true) - $startTime);
                 $mem = (int)(memory_get_usage(true) / (1024 * 1024));
                 $this->client->window->logMessage(

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -314,7 +314,6 @@ class TextDocument
             }
             $definedFqn = DefinitionResolver::getDefinedFqn($node);
             while (true) {
-                fwrite(STDERR, "searching for definition\n");
                 if ($definedFqn) {
                     // Support hover for definitions
                     $def = $this->index->getDefinition($definedFqn);

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -274,7 +274,7 @@ class TextDocument
             $fqn = DefinitionResolver::getDefinedFqn($node);
             while (true) {
                 if ($fqn) {
-                    $def = $this->index->getDefinition($definedFqn);
+                    $def = $this->index->getDefinition($fqn);
                 } else {
                     // Handle reference nodes
                     $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
@@ -314,6 +314,7 @@ class TextDocument
             }
             $definedFqn = DefinitionResolver::getDefinedFqn($node);
             while (true) {
+                fwrite(STDERR, "searching for definition\n");
                 if ($definedFqn) {
                     // Support hover for definitions
                     $def = $this->index->getDefinition($definedFqn);

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -227,6 +227,10 @@ class TextDocument
             } else {
                 // Definition with a global FQN
                 $fqn = DefinitionResolver::getDefinedFqn($node);
+                // Wait until indexing finished
+                if (!$this->index->isComplete()) {
+                    yield waitForEvent($this->index, 'complete');
+                }
                 if ($fqn === null) {
                     $fqn = $this->definitionResolver->resolveReferenceNodeToFqn($node);
                     if ($fqn === null) {

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -30,6 +30,7 @@ use LanguageServer\Index\ReadableIndex;
 use Sabre\Event\Promise;
 use Sabre\Uri;
 use function Sabre\Event\coroutine;
+use function LanguageServer\waitForEvent;
 
 /**
  * Provides method handlers for all textDocument/* methods
@@ -267,11 +268,18 @@ class TextDocument
             }
             // Handle definition nodes
             $fqn = DefinitionResolver::getDefinedFqn($node);
-            if ($fqn !== null) {
-                $def = $this->index->getDefinition($fqn);
-            } else {
-                // Handle reference nodes
-                $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+            while (true) {
+                if ($fqn) {
+                    $def = $this->index->getDefinition($definedFqn);
+                } else {
+                    // Handle reference nodes
+                    $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+                }
+                // If no result was found and we are still indexing, try again after the index was updated
+                if ($def !== null || $this->index->isComplete()) {
+                    break;
+                }
+                yield waitForEvent($this->index, 'definition-added');
             }
             if (
                 $def === null
@@ -300,14 +308,22 @@ class TextDocument
             if ($node === null) {
                 return new Hover([]);
             }
-            $range = Range::fromNode($node);
-            if ($definedFqn = DefinitionResolver::getDefinedFqn($node)) {
-                // Support hover for definitions
-                $def = $this->index->getDefinition($definedFqn);
-            } else {
-                // Get the definition for whatever node is under the cursor
-                $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+            $definedFqn = DefinitionResolver::getDefinedFqn($node);
+            while (true) {
+                if ($definedFqn) {
+                    // Support hover for definitions
+                    $def = $this->index->getDefinition($definedFqn);
+                } else {
+                    // Get the definition for whatever node is under the cursor
+                    $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+                }
+                // If no result was found and we are still indexing, try again after the index was updated
+                if ($def !== null || $this->index->isComplete()) {
+                    break;
+                }
+                yield waitForEvent($this->index, 'definition-added');
             }
+            $range = Range::fromNode($node);
             if ($def === null) {
                 return new Hover([], $range);
             }
@@ -364,12 +380,18 @@ class TextDocument
                 return [];
             }
             // Handle definition nodes
-            $fqn = DefinitionResolver::getDefinedFqn($node);
-            if ($fqn !== null) {
-                $def = $this->index->getDefinition($fqn);
-            } else {
-                // Handle reference nodes
-                $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+            while (true) {
+                if ($fqn) {
+                    $def = $this->index->getDefinition($definedFqn);
+                } else {
+                    // Handle reference nodes
+                    $def = $this->definitionResolver->resolveReferenceNodeToDefinition($node);
+                }
+                // If no result was found and we are still indexing, try again after the index was updated
+                if ($def !== null || $this->index->isComplete()) {
+                    break;
+                }
+                yield waitForEvent($this->index, 'definition-added');
             }
             if (
                 $def === null

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -8,6 +8,7 @@ use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
 use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInformation, DependencyReference, Location};
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
+use function LanguageServer\waitForEvent;
 
 /**
  * Provides method handlers for all workspace/* methods
@@ -61,17 +62,23 @@ class Workspace
      * The workspace symbol request is sent from the client to the server to list project-wide symbols matching the query string.
      *
      * @param string $query
-     * @return SymbolInformation[]
+     * @return Promise <SymbolInformation[]>
      */
-    public function symbol(string $query): array
+    public function symbol(string $query): Promise
     {
-        $symbols = [];
-        foreach ($this->index->getDefinitions() as $fqn => $definition) {
-            if ($query === '' || stripos($fqn, $query) !== false) {
-                $symbols[] = $definition->symbolInformation;
+        return coroutine(function () use ($query) {
+            // Wait until indexing finished
+            if (!$this->index->isComplete()) {
+                yield waitForEvent($this->index, 'complete');
             }
-        }
-        return $symbols;
+            $symbols = [];
+            foreach ($this->index->getDefinitions() as $fqn => $definition) {
+                if ($query === '' || stripos($fqn, $query) !== false) {
+                    $symbols[] = $definition->symbolInformation;
+                }
+            }
+            return $symbols;
+        });
     }
 
     /**
@@ -86,6 +93,10 @@ class Workspace
         return coroutine(function () use ($query, $files) {
             if ($this->composerLock === null) {
                 return [];
+            }
+            // Wait until indexing finished
+            if (!$this->index->isComplete()) {
+                yield waitForEvent($this->index, 'complete');
             }
             /** Map from URI to array of referenced FQNs in dependencies */
             $refs = [];

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -68,7 +68,7 @@ class Workspace
     {
         return coroutine(function () use ($query) {
             // Wait until indexing for definitions finished
-            if (!$this->index->isComplete()) {
+            if (!$this->index->isStaticComplete()) {
                 yield waitForEvent($this->index, 'static-complete');
             }
             $symbols = [];

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -67,9 +67,9 @@ class Workspace
     public function symbol(string $query): Promise
     {
         return coroutine(function () use ($query) {
-            // Wait until indexing finished
+            // Wait until indexing for definitions finished
             if (!$this->index->isComplete()) {
-                yield waitForEvent($this->index, 'complete');
+                yield waitForEvent($this->index, 'static-complete');
             }
             $symbols = [];
             foreach ($this->index->getDefinitions() as $fqn => $definition) {

--- a/src/utils.php
+++ b/src/utils.php
@@ -6,7 +6,7 @@ namespace LanguageServer;
 use Throwable;
 use InvalidArgumentException;
 use PhpParser\Node;
-use Sabre\Event\{Loop, Promise};
+use Sabre\Event\{Loop, Promise, EmitterInterface};
 
 /**
  * Transforms an absolute file path into a URI as used by the language server protocol.
@@ -77,6 +77,20 @@ function timeout($seconds = 0): Promise
     $promise = new Promise;
     Loop\setTimeout([$promise, 'fulfill'], $seconds);
     return $promise;
+}
+
+/**
+ * Returns a promise that is fulfilled once the passed event was triggered on the passed EventEmitter
+ *
+ * @param EmitterInterface $emitter
+ * @param string           $event
+ * @return Promise
+ */
+function waitForEvent(EmitterInterface $emitter, string $event): Promise
+{
+    $p = new Promise;
+    $emitter->once($event, [$p, 'fulfill']);
+    return $p;
 }
 
 /**

--- a/tests/Server/ServerTestCase.php
+++ b/tests/Server/ServerTestCase.php
@@ -48,6 +48,7 @@ abstract class ServerTestCase extends TestCase
         $sourceIndex       = new Index;
         $dependenciesIndex = new DependenciesIndex;
         $projectIndex      = new ProjectIndex($sourceIndex, $dependenciesIndex);
+        $projectIndex->setComplete();
 
         $definitionResolver   = new DefinitionResolver($projectIndex);
         $client               = new LanguageClient(new MockProtocolStream, new MockProtocolStream);

--- a/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/Definition/GlobalFallbackTest.php
@@ -16,6 +16,7 @@ class GlobalFallbackTest extends ServerTestCase
     public function setUp()
     {
         $projectIndex = new ProjectIndex(new Index, new DependenciesIndex);
+        $projectIndex->setComplete();
         $client = new LanguageClient(new MockProtocolStream, new MockProtocolStream);
         $definitionResolver = new DefinitionResolver($projectIndex);
         $contentRetriever = new FileSystemContentRetriever;

--- a/tests/Server/TextDocument/References/GlobalFallbackTest.php
+++ b/tests/Server/TextDocument/References/GlobalFallbackTest.php
@@ -16,6 +16,7 @@ class GlobalFallbackTest extends ServerTestCase
     public function setUp()
     {
         $projectIndex         = new ProjectIndex(new Index, new DependenciesIndex);
+        $projectIndex->setComplete();
         $definitionResolver   = new DefinitionResolver($projectIndex);
         $client               = new LanguageClient(new MockProtocolStream, new MockProtocolStream);
         $this->documentLoader = new PhpDocumentLoader(new FileSystemContentRetriever, $projectIndex, $definitionResolver);

--- a/tests/Server/Workspace/SymbolTest.php
+++ b/tests/Server/Workspace/SymbolTest.php
@@ -25,7 +25,7 @@ class SymbolTest extends ServerTestCase
     public function testEmptyQueryReturnsAllSymbols()
     {
         // Request symbols
-        $result = $this->workspace->symbol('');
+        $result = $this->workspace->symbol('')->wait();
         $referencesUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
         // @codingStandardsIgnoreStart
         $this->assertEquals([
@@ -65,7 +65,7 @@ class SymbolTest extends ServerTestCase
     public function testQueryFiltersResults()
     {
         // Request symbols
-        $result = $this->workspace->symbol('testmethod');
+        $result = $this->workspace->symbol('testmethod')->wait();
         // @codingStandardsIgnoreStart
         $this->assertEquals([
             new SymbolInformation('staticTestMethod',   SymbolKind::METHOD,    $this->getDefinitionLocation('TestNamespace\\TestClass::staticTestMethod()'), 'TestNamespace\\TestClass'),


### PR DESCRIPTION
Closes #239 
This changes the whole indexing process to be async again. The `Index` is now an `EventEmitter` that emits two events:
- `definition-added` when a Definition was added
- `complete` when the indexing has completed (triggered through `setComplete()`)

`isCompete()` returns the current status.

All methods that return multiple results that depend on the project index (`workspace/symbols`, `textDocument/references`, `workspace/xreferences`) now defer the response until indexing finished.

All methods that need to resolve a single definition (`textDocument/(x)definition`, `textDocument/hover`) check the index for a result, then if no result was found and indexing did not finish yet, check again on every added definition.

Since `LanguageServer::index` is now executed async, adds new `beforeIndex` hook.