### PR TITLE
Caching

### DIFF
--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Cache;
+
+use Sabre\Event\Promise;
+
+/**
+ * A key/value store for caching purposes
+ */
+interface Cache
+{
+    /**
+     * Gets a value from the cache
+     *
+     * @param string $key
+     * @return Promise <mixed>
+     */
+    public function get(string $key): Promise;
+
+    /**
+     * Sets a value in the cache
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @return Promise
+     */
+    public function set(string $key, $value): Promise;
+}

--- a/src/Cache/ClientCache.php
+++ b/src/Cache/ClientCache.php
@@ -27,7 +27,9 @@ class ClientCache implements Cache
      */
     public function get(string $key): Promise
     {
-        return $this->client->xcache->get($key)->then('unserialize')->otherwise(function () {});
+        return $this->client->xcache->get($key)->then('unserialize')->otherwise(function () {
+            // Ignore
+        });
     }
 
     /**
@@ -39,6 +41,8 @@ class ClientCache implements Cache
      */
     public function set(string $key, $value): Promise
     {
-        return $this->client->xcache->set($key, serialize($value))->otherwise(function () {});
+        return $this->client->xcache->set($key, serialize($value))->otherwise(function () {
+            // Ignore
+        });
     }
 }

--- a/src/Cache/ClientCache.php
+++ b/src/Cache/ClientCache.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Cache;
+
+use LanguageServer\LanguageClient;
+use Sabre\Event\Promise;
+
+/**
+ * Caches content through a xcache/* requests
+ */
+class ClientCache implements Cache
+{
+    /**
+     * @param LanguageClient $client
+     */
+    public function __construct(LanguageClient $client)
+    {
+        $this->client = $client;
+    }
+
+    /**
+     * Gets a value from the cache
+     *
+     * @param string $key
+     * @return Promise <mixed>
+     */
+    public function get(string $key): Promise
+    {
+        return $this->client->xcache->get($key)->then('unserialize')->otherwise(function () {});
+    }
+
+    /**
+     * Sets a value in the cache
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @return Promise
+     */
+    public function set(string $key, $value): Promise
+    {
+        return $this->client->xcache->set($key, serialize($value))->otherwise(function () {});
+    }
+}

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -18,10 +18,12 @@ class FileSystemCache implements Cache
 
     public function __construct()
     {
-        if (PHP_OS === 'Windows') {
-            $this->cacheDir = getenv('LOCALAPPDATA') . '\\PHP Language Server\\';
+        if (PHP_OS === 'WINNT') {
+            $this->cacheDir = $_ENV['LOCALAPPDATA'] . '\\PHP Language Server\\';
+        } else if (!empty($_ENV['XDG_CACHE_HOME'])) {
+            $this->cacheDir = $_ENV['XDG_CACHE_HOME'] . '/phpls/';
         } else {
-            $this->cacheDir = getenv('HOME') . '/.phpls/';
+            $this->cacheDir = $_ENV['HOME'] . '/.phpls/';
         }
     }
 

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -59,8 +59,7 @@ class FileSystemCache implements Cache
                 mkdir($this->cacheDir);
             }
             file_put_contents($file, serialize($value));
-            return Promise\resolve(null);
-        } catch (\Exception $e) {
+        } finally {
             return Promise\resolve(null);
         }
     }

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -19,11 +19,11 @@ class FileSystemCache implements Cache
     public function __construct()
     {
         if (PHP_OS === 'WINNT') {
-            $this->cacheDir = $_ENV['LOCALAPPDATA'] . '\\PHP Language Server\\';
-        } else if (!empty($_ENV['XDG_CACHE_HOME'])) {
-            $this->cacheDir = $_ENV['XDG_CACHE_HOME'] . '/phpls/';
+            $this->cacheDir = getenv('LOCALAPPDATA') . '\\PHP Language Server\\';
+        } else if (getenv('XDG_CACHE_HOME')) {
+            $this->cacheDir = getenv('XDG_CACHE_HOME') . '/phpls/';
         } else {
-            $this->cacheDir = $_ENV['HOME'] . '/.phpls/';
+            $this->cacheDir = getenv('HOME') . '/.phpls/';
         }
     }
 

--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Cache;
+
+use LanguageServer\LanguageClient;
+use Sabre\Event\Promise;
+
+/**
+ * Caches content on the file system
+ */
+class FileSystemCache implements Cache
+{
+    /**
+     * @var string
+     */
+    public $cacheDir;
+
+    public function __construct()
+    {
+        if (PHP_OS === 'Windows') {
+            $this->cacheDir = getenv('LOCALAPPDATA') . '\\PHP Language Server\\';
+        } else {
+            $this->cacheDir = getenv('HOME') . '/.phpls/';
+        }
+    }
+
+    /**
+     * Gets a value from the cache
+     *
+     * @param string $key
+     * @return Promise <mixed>
+     */
+    public function get(string $key): Promise
+    {
+        try {
+            $file = $this->cacheDir . urlencode($key);
+            if (!file_exists($file)) {
+                return Promise\resolve(null);
+            }
+            return Promise\resolve(unserialize(file_get_contents($file)));
+        } catch (\Exception $e) {
+            return Promise\resolve(null);
+        }
+    }
+
+    /**
+     * Sets a value in the cache
+     *
+     * @param string $key
+     * @param mixed  $value
+     * @return Promise
+     */
+    public function set(string $key, $value): Promise
+    {
+        try {
+            $file = $this->cacheDir . urlencode($key);
+            if (!file_exists($this->cacheDir)) {
+                mkdir($this->cacheDir);
+            }
+            file_put_contents($file, serialize($value));
+            return Promise\resolve(null);
+        } catch (\Exception $e) {
+            return Promise\resolve(null);
+        }
+    }
+}

--- a/src/Client/XCache.php
+++ b/src/Client/XCache.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Client;
+
+use LanguageServer\ClientHandler;
+use LanguageServer\Protocol\Message;
+use Sabre\Event\Promise;
+
+/**
+ * Provides method handlers for all xcache/* methods
+ */
+class XCache
+{
+    /**
+     * @var ClientHandler
+     */
+    private $handler;
+
+    public function __construct(ClientHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * @param string $key
+     * @return Promise <mixed>
+     */
+    public function get(string $key): Promise
+    {
+        return $this->handler->request('xcache/get', ['key' => $key]);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     * @return Promise <mixed>
+     */
+    public function set(string $key, $value): Promise
+    {
+        return $this->handler->notify('xcache/set', ['key' => $key, 'value' => $value]);
+    }
+}

--- a/src/Index/DependenciesIndex.php
+++ b/src/Index/DependenciesIndex.php
@@ -15,7 +15,7 @@ class DependenciesIndex extends AbstractAggregateIndex
     /**
      * @return Index[]
      */
-    protected function getIndexes(): array
+    public function getIndexes(): array
     {
         return $this->indexes;
     }
@@ -32,6 +32,17 @@ class DependenciesIndex extends AbstractAggregateIndex
             $this->registerIndex($index);
         }
         return $this->indexes[$packageName];
+    }
+
+    /**
+     * @param string $packageName
+     * @param Index  $index
+     * @return void
+     */
+    public function setDependencyIndex(string $packageName, Index $index)
+    {
+        $this->indexes[$packageName] = $index;
+        $this->registerIndex($index);
     }
 
     /**

--- a/src/Index/DependenciesIndex.php
+++ b/src/Index/DependenciesIndex.php
@@ -15,7 +15,7 @@ class DependenciesIndex extends AbstractAggregateIndex
     /**
      * @return Index[]
      */
-    public function getIndexes(): array
+    protected function getIndexes(): array
     {
         return $this->indexes;
     }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -208,7 +208,7 @@ class Index implements ReadableIndex, \Serializable
             'definitions' => $this->definitions,
             'references' => $this->references,
             'complete' => $this->complete,
-            'static-complete' => $this->staticComplete
+            'staticComplete' => $this->staticComplete
         ]);
     }
 }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -10,7 +10,7 @@ use Sabre\Event\EmitterTrait;
  * Represents the index of a project or dependency
  * Serializable for caching
  */
-class Index implements ReadableIndex
+class Index implements ReadableIndex, \Serializable
 {
     use EmitterTrait;
 
@@ -184,5 +184,31 @@ class Index implements ReadableIndex
             return;
         }
         array_splice($this->references[$fqn], $index, 1);
+    }
+
+    /**
+     * @param string $serialized
+     * @return void
+     */
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+        foreach ($data as $prop => $val) {
+            $this->$prop = $val;
+        }
+    }
+
+    /**
+     * @param string $serialized
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize([
+            'definitions' => $this->definitions,
+            'references' => $this->references,
+            'complete' => $this->complete,
+            'static-complete' => $this->staticComplete
+        ]);
     }
 }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer;
+
+use LanguageServer\Cache\Cache;
+use LanguageServer\FilesFinder\FilesFinder;
+use LanguageServer\Index\{DependenciesIndex, Index};
+use LanguageServer\Protocol\MessageType;
+use Webmozart\PathUtil\Path;
+use Composer\Semver\VersionParser;
+use Sabre\Event\Promise;
+use function Sabre\Event\coroutine;
+
+class Indexer
+{
+    /**
+     * @var The prefix for every cache item
+     */
+    const CACHE_VERSION = 1;
+
+    /**
+     * @var FilesFinder
+     */
+    private $filesFinder;
+
+    /**
+     * @var string
+     */
+    private $rootPath;
+
+    /**
+     * @var LanguageClient
+     */
+    private $client;
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * @var DependenciesIndex
+     */
+    private $dependenciesIndex;
+
+    /**
+     * @var Index
+     */
+    private $sourceIndex;
+
+    /**
+     * @var PhpDocumentLoader
+     */
+    private $documentLoader;
+
+    /**
+     * @var \stdClasss
+     */
+    private $composerLock;
+
+    /**
+     * @param FilesFinder       $filesFinder
+     * @param string            $rootPath
+     * @param LanguageClient    $client
+     * @param Cache             $cache
+     * @param DependenciesIndex $dependenciesIndex
+     * @param Index             $sourceIndex
+     * @param PhpDocumentLoader $documentLoader
+     * @param \stdClass|null    $composerLock
+     */
+    public function __construct(
+        FilesFinder $filesFinder,
+        string $rootPath,
+        LanguageClient $client,
+        Cache $cache,
+        DependenciesIndex $dependenciesIndex,
+        Index $sourceIndex,
+        PhpDocumentLoader $documentLoader,
+        \stdClass $composerLock = null
+    ) {
+        $this->filesFinder = $filesFinder;
+        $this->rootPath = $rootPath;
+        $this->client = $client;
+        $this->cache = $cache;
+        $this->dependenciesIndex = $dependenciesIndex;
+        $this->sourceIndex = $sourceIndex;
+        $this->documentLoader = $documentLoader;
+        $this->composerLock = $composerLock;
+    }
+
+    /**
+     * Will read and parse the passed source files in the project and add them to the appropiate indexes
+     *
+     * @return Promise <void>
+     */
+    public function index(): Promise
+    {
+        return coroutine(function () {
+
+            $pattern = Path::makeAbsolute('**/*.php', $this->rootPath);
+            $uris = yield $this->filesFinder->find($pattern);
+
+            $count = count($uris);
+            $startTime = microtime(true);
+            $this->client->window->logMessage(MessageType::INFO, "$count files total");
+
+            /** @var string[] */
+            $source = [];
+            /** @var string[][] */
+            $deps = [];
+            foreach ($uris as $uri) {
+                if ($this->composerLock !== null && preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $uri, $matches)) {
+                    // Dependency file
+                    $packageName = $matches[1];
+                    if (!isset($deps[$packageName])) {
+                        $deps[$packageName] = [];
+                    }
+                    $deps[$packageName][] = $uri;
+                } else {
+                    // Source file
+                    $source[] = $uri;
+                }
+            }
+
+            // Index source
+            // Definitions and static references
+            $this->client->window->logMessage(MessageType::INFO, 'Indexing project for definitions and static references');
+            yield $this->indexFiles($source);
+            $this->sourceIndex->setStaticComplete();
+            // Dynamic references
+            $this->client->window->logMessage(MessageType::INFO, 'Indexing project for dynamic references');
+            yield $this->indexFiles($source);
+            $this->sourceIndex->setComplete();
+
+            // Index dependencies
+            $this->client->window->logMessage(MessageType::INFO, count($deps) . ' Packages');
+            foreach ($deps as $packageName => $files) {
+                // Find version of package and check cache
+                $packageKey = null;
+                $cacheKey = null;
+                $index = null;
+                foreach (array_merge($this->composerLock->packages, $this->composerLock->{'packages-dev'}) as $package) {
+                    // Check if package name matches and version is absolute
+                    // Dynamic constraints are not cached, because they can change every time
+                    $packageVersion = ltrim($package->version, 'v');
+                    if ($package->name === $packageName && strpos($packageVersion, 'dev') === false) {
+                        $packageKey = $packageName . ':' . $packageVersion;
+                        $cacheKey = self::CACHE_VERSION . ':' . $packageKey;
+                        // Check cache
+                        $index = yield $this->cache->get($cacheKey);
+                        break;
+                    }
+                }
+                if ($index !== null) {
+                    // Cache hit
+                    $this->dependenciesIndex->setDependencyIndex($packageName, $index);
+                    $this->client->window->logMessage(MessageType::INFO, "Restored $packageKey from cache");
+                } else {
+                    // Cache miss
+                    $index = $this->dependenciesIndex->getDependencyIndex($packageName);
+
+                    // Index definitions and static references
+                    $this->client->window->logMessage(MessageType::INFO, 'Indexing ' . ($packageKey ?? $packageName) . ' for definitions and static references');
+                    yield $this->indexFiles($files);
+                    $index->setStaticComplete();
+
+                    // Index dynamic references
+                    $this->client->window->logMessage(MessageType::INFO, 'Indexing ' . ($packageKey ?? $packageName) . ' for dynamic references');
+                    yield $this->indexFiles($files);
+                    $index->setComplete();
+
+                    // If we know the version (cache key), save index for the dependency in the cache
+                    if ($cacheKey !== null) {
+                        $this->client->window->logMessage(MessageType::INFO, "Storing $packageKey in cache");
+                        $this->cache->set($cacheKey, $index);
+                    }
+                }
+            }
+
+            $duration = (int)(microtime(true) - $startTime);
+            $mem = (int)(memory_get_usage(true) / (1024 * 1024));
+            $this->client->window->logMessage(
+                MessageType::INFO,
+                "All $count PHP files parsed in $duration seconds. $mem MiB allocated."
+            );
+        });
+    }
+
+    /**
+     * @param array $files
+     * @return Promise
+     */
+    private function indexFiles(array $files): Promise
+    {
+        return coroutine(function () use ($files) {
+            foreach ($files as $i => $uri) {
+                // Skip open documents
+                if ($this->documentLoader->isOpen($uri)) {
+                    continue;
+                }
+
+                // Give LS to the chance to handle requests while indexing
+                yield timeout();
+                $this->client->window->logMessage(MessageType::LOG, "Parsing $uri");
+                try {
+                    $document = yield $this->documentLoader->load($uri);
+                    if (!$document->isVendored()) {
+                        $this->client->textDocument->publishDiagnostics($uri, $document->getDiagnostics());
+                    }
+                } catch (ContentTooLargeException $e) {
+                    $this->client->window->logMessage(
+                        MessageType::INFO,
+                        "Ignoring file {$uri} because it exceeds size limit of {$e->limit} bytes ({$e->size})"
+                    );
+                } catch (\Exception $e) {
+                    $this->client->window->logMessage(MessageType::ERROR, "Error parsing $uri: " . (string)$e);
+                }
+            }
+        });
+    }
+}

--- a/src/LanguageClient.php
+++ b/src/LanguageClient.php
@@ -28,6 +28,13 @@ class LanguageClient
      */
     public $workspace;
 
+    /**
+     * Handles xcache/* methods
+     *
+     * @var Client\XCache
+     */
+    public $xcache;
+
     public function __construct(ProtocolReader $reader, ProtocolWriter $writer)
     {
         $handler = new ClientHandler($reader, $writer);
@@ -36,5 +43,6 @@ class LanguageClient
         $this->textDocument = new Client\TextDocument($handler, $mapper);
         $this->window = new Client\Window($handler);
         $this->workspace = new Client\Workspace($handler, $mapper);
+        $this->xcache = new Client\XCache($handler);
     }
 }

--- a/src/Protocol/ClientCapabilities.php
+++ b/src/Protocol/ClientCapabilities.php
@@ -17,4 +17,11 @@ class ClientCapabilities
      * @var bool|null
      */
     public $xcontentProvider;
+
+    /**
+     * The client supports xcache/* requests
+     *
+     * @var bool|null
+     */
+    public $xcacheProvider;
 }

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -104,11 +104,7 @@ class LanguageServerTest extends TestCase
                         $promise->reject(new Exception($msg->body->params->message));
                     }
                 } else if (strpos($msg->body->params->message, 'All 25 PHP files parsed') !== false) {
-                    if ($run === 1) {
-                        $run++;
-                    } else {
-                        $promise->fulfill();
-                    }
+                    $promise->fulfill();
                 }
             }
         });


### PR DESCRIPTION
Closes #47 

Implements the [cache extension](https://github.com/sourcegraph/language-server-protocol/blob/68c291281db65eb41ad9890e71c962bda92b5e03/extension-chache.md) and alternatively falls back to the file system.
Cache directory is `~/.phpls` on Linux/Mac and `%LOCALAPPDATA%/PHP Language Server` on Windows.

The index for each dependency gets serialized and saved in the cache, keyed by package name and version.

Indexing is now done by the `Indexer` class.