### PR TITLE
Remove CompletionItem.textEdit

### DIFF
--- a/src/CompletionProvider.php
+++ b/src/CompletionProvider.php
@@ -6,8 +6,6 @@ namespace LanguageServer;
 use PhpParser\Node;
 use LanguageServer\Index\ReadableIndex;
 use LanguageServer\Protocol\{
-    TextEdit,
-    Range,
     Position,
     CompletionList,
     CompletionItem,
@@ -272,18 +270,10 @@ class CompletionProvider
                 $item->label = '$' . ($var instanceof Node\Expr\ClosureUse ? $var->var : $var->name);
                 $item->documentation = $this->definitionResolver->getDocumentationFromNode($var);
                 $item->detail = (string)$this->definitionResolver->getTypeFromNode($var);
-                $item->textEdit = new TextEdit(
-                    new Range($pos, $pos),
-                    stripStringOverlap($doc->getRange(new Range(new Position(0, 0), $pos)), $item->label)
-                );
                 $list->items[] = $item;
             }
         } else if ($node instanceof Node\Stmt\InlineHTML || $pos == new Position(0, 0)) {
             $item = new CompletionItem('<?php', CompletionItemKind::KEYWORD);
-            $item->textEdit = new TextEdit(
-                new Range($pos, $pos),
-                stripStringOverlap($doc->getRange(new Range(new Position(0, 0), $pos)), '<?php')
-            );
             $list->items[] = $item;
         }
 

--- a/src/Protocol/CompletionItem.php
+++ b/src/Protocol/CompletionItem.php
@@ -64,13 +64,16 @@ class CompletionItem
     public $insertText;
 
     /**
-     * An edit which is applied to a document when selecting
-     * this completion. When an edit is provided the value of
-     * insertText is ignored.
+     * A range of text that should be replaced by this completion item.
      *
-     * @var TextEdit|null
+     * Defaults to a range from the start of the current word to the current position.
+     *
+     * *Note:* The range must be a single line range and it must contain the position at which completion
+     * has been requested.
+     *
+     * @var Range|null
      */
-    public $textEdit;
+    public $range;
 
     /**
      * An optional array of additional text edits that are applied when
@@ -106,7 +109,7 @@ class CompletionItem
      * @param string|null     $sortText
      * @param string|null     $filterText
      * @param string|null     $insertText
-     * @param TextEdit|null   $textEdit
+     * @param Range|null      $range
      * @param TextEdit[]|null $additionalTextEdits
      * @param Command|null    $command
      * @param mixed|null      $data
@@ -119,7 +122,7 @@ class CompletionItem
         string $sortText = null,
         string $filterText = null,
         string $insertText = null,
-        TextEdit $textEdit = null,
+        Range $range = null,
         array $additionalTextEdits = null,
         Command $command = null,
         $data = null
@@ -131,7 +134,7 @@ class CompletionItem
         $this->sortText = $sortText;
         $this->filterText = $filterText;
         $this->insertText = $insertText;
-        $this->textEdit = $textEdit;
+        $this->range = $range;
         $this->additionalTextEdits = $additionalTextEdits;
         $this->command = $command;
         $this->data = $data;

--- a/src/Protocol/CompletionItem.php
+++ b/src/Protocol/CompletionItem.php
@@ -64,6 +64,14 @@ class CompletionItem
     public $insertText;
 
     /**
+     * The format of the insert text. The format applies to both the `insertText` property
+     * and the `newText` property of a provided `textEdit`.
+     *
+     * @var InsertTextFormat|null
+     */
+    public $insertTextFormat;
+
+    /**
      * A range of text that should be replaced by this completion item.
      *
      * Defaults to a range from the start of the current word to the current position.

--- a/src/Protocol/InsertTextFormat.php
+++ b/src/Protocol/InsertTextFormat.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+/**
+ * Defines whether the insert text in a completion item should be interpreted as
+ * plain text or a snippet.
+ */
+abstract class InsertTextFormat
+{
+    /**
+     * The primary text to be inserted is treated as a plain string.
+     */
+    const PLAIN_TEXT = 1;
+
+    /**
+     * The primary text to be inserted is treated as a snippet.
+     *
+     * A snippet can define tab stops and placeholders with `$1`, `$2`
+     * and `${3:foo}`. `$0` defines the final tab stop, it defaults to
+     * the end of the snippet. Placeholders with equal identifiers are linked,
+     * that is typing in one will update others too.
+     *
+     * See also: https://github.com/Microsoft/vscode/blob/master/src/vs/editor/contrib/snippet/common/snippet.md
+     */
+    const SNIPPET = 2;
+}

--- a/src/utils.php
+++ b/src/utils.php
@@ -109,25 +109,3 @@ function getClosestNode(Node $node, string $type)
         }
     }
 }
-
-/**
- * Returns the part of $b that is not overlapped by $a
- * Example:
- *
- *     stripStringOverlap('whatever<?', '<?php') === 'php'
- *
- * @param string $a
- * @param string $b
- * @return string
- */
-function stripStringOverlap(string $a, string $b): string
-{
-    $aLen = strlen($a);
-    $bLen = strlen($b);
-    for ($i = 1; $i <= $bLen; $i++) {
-        if (substr($b, 0, $i) === substr($a, $aLen - $i)) {
-            return substr($b, $i);
-        }
-    }
-    return $b;
-}


### PR DESCRIPTION
`textEdit` is deprecated. `insertText` should be used. `range` defaults to the current word, so I will leave it out for now and add it back when we can use node offset information for this.