### PR TITLE
Automatically index stubs on composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     ],
     "bin": ["bin/php-language-server.php"],
     "scripts": {
-        "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs"
+        "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs",
+        "post-install-cmd": "@parse-stubs"
     },
     "require": {
         "php": ">=7.0",


### PR DESCRIPTION
This will only run automatically when a developer runs composer install - this is not run for anyone that gets this package as a requirement of some other package (so projects that require the language server will still have to manually index the stubs).