### PR TITLE
Read vendor directory from project's composer.json, if set.

### DIFF
--- a/src/Index/ProjectIndex.php
+++ b/src/Index/ProjectIndex.php
@@ -22,10 +22,11 @@ class ProjectIndex extends AbstractAggregateIndex
      */
     private $sourceIndex;
 
-    public function __construct(Index $sourceIndex, DependenciesIndex $dependenciesIndex)
+    public function __construct(Index $sourceIndex, DependenciesIndex $dependenciesIndex, \stdClass $composerJson = null)
     {
         $this->sourceIndex = $sourceIndex;
         $this->dependenciesIndex = $dependenciesIndex;
+        $this->composerJson = $composerJson;
         parent::__construct();
     }
 
@@ -43,7 +44,7 @@ class ProjectIndex extends AbstractAggregateIndex
      */
     public function getIndexForUri(string $uri): Index
     {
-        if (preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $uri, $matches)) {
+        if (\LanguageServer\uriInVendorDir($this->composerJson, $uri, $matches)) {
             $packageName = $matches[1];
             return $this->dependenciesIndex->getDependencyIndex($packageName);
         }

--- a/src/Index/ProjectIndex.php
+++ b/src/Index/ProjectIndex.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace LanguageServer\Index;
 
+use function LanguageServer\getPackageName;
+
 /**
  * A project index manages the source and dependency indexes
  */
@@ -44,8 +46,8 @@ class ProjectIndex extends AbstractAggregateIndex
      */
     public function getIndexForUri(string $uri): Index
     {
-        if (\LanguageServer\uriInVendorDir($this->composerJson, $uri, $matches)) {
-            $packageName = $matches[1];
+        $packageName = getPackageName($this->composerJson, $uri);
+        if ($packageName) {
             return $this->dependenciesIndex->getDependencyIndex($packageName);
         }
         return $this->sourceIndex;

--- a/src/Index/ProjectIndex.php
+++ b/src/Index/ProjectIndex.php
@@ -46,7 +46,7 @@ class ProjectIndex extends AbstractAggregateIndex
      */
     public function getIndexForUri(string $uri): Index
     {
-        $packageName = getPackageName($this->composerJson, $uri);
+        $packageName = getPackageName($uri, $this->composerJson);
         if ($packageName) {
             return $this->dependenciesIndex->getDependencyIndex($packageName);
         }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -186,7 +186,7 @@ class Indexer
                         $this->client->window->logMessage(MessageType::INFO, "Storing $packageKey in cache");
                         $this->cache->set($cacheKey, $index);
                     } else {
-                        $this->client->window->logMessage(MessageType::INFO, "Cannot cache $packageName, cache key was null. Either you are using a 'dev-' version or your composer.lock is missing references.");
+                        $this->client->window->logMessage(MessageType::WARNING, "Could not compute cache key for $packageName");
                     }
                 }
             }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -117,7 +117,10 @@ class Indexer
             /** @var string[][] */
             $deps = [];
 
-            $vendorDir = str_replace('/', '\/', @$this->composerJson->config->{'vendor-dir'} ?: 'vendor');
+            $vendorDir = isset($this->composerJson->config->{'vendor-dir'}) ?
+                $this->composerJson->config->{'vendor-dir'}
+                : 'vendor';
+            $vendorDir = str_replace('/', '\/', $vendorDir);
             $this->client->window->logMessage(MessageType::INFO, "Vendor dir: $vendorDir");
 
             foreach ($uris as $uri) {

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -118,9 +118,9 @@ class Indexer
             $deps = [];
 
             foreach ($uris as $uri) {
-                if ($this->composerLock !== null && uriInVendorDir($this->composerJson, $uri, $matches)) {
+                $packageName = getPackageName($this->composerJson, $uri);
+                if ($this->composerLock !== null && $packageName) {
                     // Dependency file
-                    $packageName = $matches[1];
                     if (!isset($deps[$packageName])) {
                         $deps[$packageName] = [];
                     }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -117,14 +117,8 @@ class Indexer
             /** @var string[][] */
             $deps = [];
 
-            $vendorDir = isset($this->composerJson->config->{'vendor-dir'}) ?
-                $this->composerJson->config->{'vendor-dir'}
-                : 'vendor';
-            $vendorDir = str_replace('/', '\/', $vendorDir);
-            $this->client->window->logMessage(MessageType::INFO, "Vendor dir: $vendorDir");
-
             foreach ($uris as $uri) {
-                if ($this->composerLock !== null && preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches)) {
+                if ($this->composerLock !== null && uriInVendorDir($this->composerJson, $uri, $matches)) {
                     // Dependency file
                     $packageName = $matches[1];
                     if (!isset($deps[$packageName])) {
@@ -221,7 +215,7 @@ class Indexer
                 $this->client->window->logMessage(MessageType::LOG, "Parsing $uri");
                 try {
                     $document = yield $this->documentLoader->load($uri);
-                    if (!$document->isVendored()) {
+                    if (!isVendored($document, $this->composerJson)) {
                         $this->client->textDocument->publishDiagnostics($uri, $document->getDiagnostics());
                     }
                 } catch (ContentTooLargeException $e) {

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -118,7 +118,7 @@ class Indexer
             $deps = [];
 
             foreach ($uris as $uri) {
-                $packageName = getPackageName($this->composerJson, $uri);
+                $packageName = getPackageName($uri, $this->composerJson);
                 if ($this->composerLock !== null && $packageName) {
                     // Dependency file
                     if (!isset($deps[$packageName])) {

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -206,6 +206,13 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Find composer.json
                 if ($this->composerJson === null) {
                     $composerJsonFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.json', $rootPath));
+
+                    // If we sort our findings by string length (shortest to longest),
+                    // the first entry will be the project's root composer.json.
+                    usort($composerJsonFiles, function ($a, $b) {
+                        return strlen($a) - strlen($b);
+                    });
+
                     if (!empty($composerJsonFiles)) {
                         $this->composerJson = json_decode(yield $this->contentRetriever->retrieve($composerJsonFiles[0]));
                     }
@@ -214,6 +221,13 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Find composer.lock
                 if ($this->composerLock === null) {
                     $composerLockFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.lock', $rootPath));
+
+                    // If we sort our findings by string length (shortest to longest),
+                    // the first entry will be the project's root composer.lock.
+                    usort($composerLockFiles, function ($a, $b) {
+                        return strlen($a) - strlen($b);
+                    });
+
                     if (!empty($composerLockFiles)) {
                         $this->composerLock = json_decode(yield $this->contentRetriever->retrieve($composerLockFiles[0]));
                     }
@@ -230,7 +244,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     $dependenciesIndex,
                     $sourceIndex,
                     $this->documentLoader,
-                    $this->composerLock
+                    $this->composerLock,
+                    $this->composerJson
                 );
                 $indexer->index()->otherwise('\\LanguageServer\\crash');
             }

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -187,7 +187,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
             $dependenciesIndex = new DependenciesIndex;
             $sourceIndex = new Index;
-            $this->projectIndex = new ProjectIndex($sourceIndex, $dependenciesIndex);
+            $this->projectIndex = new ProjectIndex($sourceIndex, $dependenciesIndex, $this->composerJson);
             $stubsIndex = StubsIndex::read();
             $this->globalIndex = new GlobalIndex($stubsIndex, $this->projectIndex);
 
@@ -257,7 +257,8 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     $dependenciesIndex,
                     $sourceIndex,
                     $this->composerLock,
-                    $this->documentLoader
+                    $this->documentLoader,
+                    $this->composerJson
                 );
             }
 

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -25,6 +25,7 @@ use Exception;
 use Throwable;
 use Webmozart\PathUtil\Path;
 use Sabre\Uri;
+use function LanguageServer\sortByLeastSlashes;
 
 class LanguageServer extends AdvancedJsonRpc\Dispatcher
 {
@@ -206,12 +207,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Find composer.json
                 if ($this->composerJson === null) {
                     $composerJsonFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.json', $rootPath));
-
-                    // If we sort our findings by string length (shortest to longest),
+                    // If we sort our findings by number of slashes (least to greatest),
                     // the first entry will be the project's root composer.json.
-                    usort($composerJsonFiles, function ($a, $b) {
-                        return strlen($a) - strlen($b);
-                    });
+                    usort($composerJsonFiles, 'LanguageServer\sortByLeastSlashes');
 
                     if (!empty($composerJsonFiles)) {
                         $this->composerJson = json_decode(yield $this->contentRetriever->retrieve($composerJsonFiles[0]));
@@ -222,11 +220,9 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 if ($this->composerLock === null) {
                     $composerLockFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.lock', $rootPath));
 
-                    // If we sort our findings by string length (shortest to longest),
+                    // If we sort our findings by number of slashes (least to greatest),
                     // the first entry will be the project's root composer.lock.
-                    usort($composerLockFiles, function ($a, $b) {
-                        return strlen($a) - strlen($b);
-                    });
+                    usort($composerLockFiles, 'LanguageServer\sortByLeastSlashes');
 
                     if (!empty($composerLockFiles)) {
                         $this->composerLock = json_decode(yield $this->contentRetriever->retrieve($composerLockFiles[0]));

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -25,7 +25,6 @@ use Exception;
 use Throwable;
 use Webmozart\PathUtil\Path;
 use Sabre\Uri;
-use function LanguageServer\sortByLeastSlashes;
 
 class LanguageServer extends AdvancedJsonRpc\Dispatcher
 {
@@ -207,9 +206,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Find composer.json
                 if ($this->composerJson === null) {
                     $composerJsonFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.json', $rootPath));
-                    // If we sort our findings by number of slashes (least to greatest),
-                    // the first entry will be the project's root composer.json.
-                    usort($composerJsonFiles, 'LanguageServer\sortByLeastSlashes');
+                    sortUrisLevelOrder($composerJsonFiles);
 
                     if (!empty($composerJsonFiles)) {
                         $this->composerJson = json_decode(yield $this->contentRetriever->retrieve($composerJsonFiles[0]));
@@ -219,10 +216,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 // Find composer.lock
                 if ($this->composerLock === null) {
                     $composerLockFiles = yield $this->filesFinder->find(Path::makeAbsolute('**/composer.lock', $rootPath));
-
-                    // If we sort our findings by number of slashes (least to greatest),
-                    // the first entry will be the project's root composer.lock.
-                    usort($composerLockFiles, 'LanguageServer\sortByLeastSlashes');
+                    sortUrisLevelOrder($composerLockFiles);
 
                     if (!empty($composerLockFiles)) {
                         $this->composerLock = json_decode(yield $this->contentRetriever->retrieve($composerLockFiles[0]));

--- a/src/PhpDocument.php
+++ b/src/PhpDocument.php
@@ -221,17 +221,6 @@ class PhpDocument
     }
 
     /**
-     * Returns true if the document is a dependency
-     *
-     * @return bool
-     */
-    public function isVendored(): bool
-    {
-        $path = Uri\parse($this->uri)['path'];
-        return strpos($path, '/vendor/') !== false;
-    }
-
-    /**
      * Returns array of TextEdit changes to format this document.
      *
      * @return \LanguageServer\Protocol\TextEdit[]

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -30,7 +30,7 @@ use LanguageServer\Index\ReadableIndex;
 use Sabre\Event\Promise;
 use Sabre\Uri;
 use function Sabre\Event\coroutine;
-use function LanguageServer\waitForEvent;
+use function LanguageServer\{waitForEvent,isVendored};
 
 /**
  * Provides method handlers for all textDocument/* methods
@@ -134,7 +134,7 @@ class TextDocument
     public function didOpen(TextDocumentItem $textDocument)
     {
         $document = $this->documentLoader->open($textDocument->uri, $textDocument->text);
-        if (!\LanguageServer\isVendored($document, $this->composerJson)) {
+        if (!isVendored($document, $this->composerJson)) {
             $this->client->textDocument->publishDiagnostics($textDocument->uri, $document->getDiagnostics());
         }
     }
@@ -409,9 +409,9 @@ class TextDocument
                 $symbol->$prop = $val;
             }
             $symbol->fqsen = $def->fqn;
-            if (preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $def->symbolInformation->location->uri, $matches) && $this->composerLock !== null) {
+            $packageName = getPackageName($def->symbolInformation->location->uri, $this->composerJson);
+            if ($packageName && $this->composerLock !== null) {
                 // Definition is inside a dependency
-                $packageName = $matches[1];
                 foreach (array_merge($this->composerLock->packages, $this->composerLock->{'packages-dev'}) as $package) {
                     if ($package->name === $packageName) {
                         $symbol->package = $package;

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -134,7 +134,7 @@ class TextDocument
     public function didOpen(TextDocumentItem $textDocument)
     {
         $document = $this->documentLoader->open($textDocument->uri, $textDocument->text);
-        if (!$document->isVendored()) {
+        if (!\LanguageServer\isVendored($document, $this->composerJson)) {
             $this->client->textDocument->publishDiagnostics($textDocument->uri, $document->getDiagnostics());
         }
     }

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -30,7 +30,7 @@ use LanguageServer\Index\ReadableIndex;
 use Sabre\Event\Promise;
 use Sabre\Uri;
 use function Sabre\Event\coroutine;
-use function LanguageServer\{waitForEvent,isVendored};
+use function LanguageServer\{waitForEvent, isVendored};
 
 /**
  * Provides method handlers for all textDocument/* methods

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -49,13 +49,14 @@ class Workspace
      * @param \stdClass         $composerLock      The parsed composer.lock of the project, if any
      * @param PhpDocumentLoader $documentLoader    PhpDocumentLoader instance to load documents
      */
-    public function __construct(ProjectIndex $index, DependenciesIndex $dependenciesIndex, Index $sourceIndex, \stdClass $composerLock = null, PhpDocumentLoader $documentLoader)
+    public function __construct(ProjectIndex $index, DependenciesIndex $dependenciesIndex, Index $sourceIndex, \stdClass $composerLock = null, PhpDocumentLoader $documentLoader, \stdClass $composerJson = null)
     {
         $this->sourceIndex = $sourceIndex;
         $this->index = $index;
         $this->dependenciesIndex = $dependenciesIndex;
         $this->composerLock = $composerLock;
         $this->documentLoader = $documentLoader;
+        $this->composerJson = $composerJson;
     }
 
     /**
@@ -122,7 +123,7 @@ class Workspace
                         $symbol->$prop = $val;
                     }
                     // Find out package name
-                    preg_match('/\/vendor\/([^\/]+\/[^\/]+)\//', $def->symbolInformation->location->uri, $matches);
+                    uriInVendorDir($this->composerJson, $def->symbolInformation->location->uri, $matches);
                     $packageName = $matches[1];
                     foreach ($this->composerLock->packages as $package) {
                         if ($package->name === $packageName) {

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -8,7 +8,7 @@ use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
 use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInformation, DependencyReference, Location};
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
-use function LanguageServer\{waitForEvent,getPackageName};
+use function LanguageServer\{waitForEvent, getPackageName};
 
 /**
  * Provides method handlers for all workspace/* methods

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -8,8 +8,7 @@ use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
 use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInformation, DependencyReference, Location};
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
-use function LanguageServer\waitForEvent;
-use function LanguageServer\getPackageName;
+use function LanguageServer\{waitForEvent,getPackageName};
 
 /**
  * Provides method handlers for all workspace/* methods
@@ -124,7 +123,7 @@ class Workspace
                         $symbol->$prop = $val;
                     }
                     // Find out package name
-                    $packageName = getPackageName($this->composerJson, $def->symbolInformation->location->uri);
+                    $packageName = getPackageName($def->symbolInformation->location->uri, $this->composerJson);
                     foreach (array_merge($this->composerLock->packages, $this->composerLock->{'packages-dev'}) as $package) {
                         if ($package->name === $packageName) {
                             $symbol->package = $package;

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -9,6 +9,7 @@ use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInfor
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
 use function LanguageServer\waitForEvent;
+use function LanguageServer\getPackageName;
 
 /**
  * Provides method handlers for all workspace/* methods
@@ -123,8 +124,7 @@ class Workspace
                         $symbol->$prop = $val;
                     }
                     // Find out package name
-                    uriInVendorDir($this->composerJson, $def->symbolInformation->location->uri, $matches);
-                    $packageName = $matches[1];
+                    $packageName = getPackageName($this->composerJson, $def->symbolInformation->location->uri);
                     foreach ($this->composerLock->packages as $package) {
                         if ($package->name === $packageName) {
                             $symbol->package = $package;

--- a/src/utils.php
+++ b/src/utils.php
@@ -169,13 +169,13 @@ function isVendored(PhpDocument $document, \stdClass $composerJson = null): bool
  * @param \stdClass|null $composerJson
  * @param string         $uri
  * @param array          $matches
- * @return string
+ * @return string|null
  */
-function getPackageName(\stdClass $composerJson = null, string $uri): ?string
+function getPackageName(string $uri, \stdClass $composerJson = null): ?string
 {
     $vendorDir = str_replace('/', '\/', getVendorDir($composerJson));
     preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches);
-    return isset($matches[1]) ? $matches[1] : null;
+    return $matches[1] ?? null;
 }
 
 /**
@@ -187,7 +187,5 @@ function getPackageName(\stdClass $composerJson = null, string $uri): ?string
  */
 function getVendorDir(\stdClass $composerJson = null): string
 {
-    return isset($composerJson->config->{'vendor-dir'}) ?
-        $composerJson->config->{'vendor-dir'}
-        : 'vendor';
+    return $composerJson->config->{'vendor-dir'} ?? 'vendor';
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -171,7 +171,7 @@ function isVendored(PhpDocument $document, \stdClass $composerJson = null): bool
  * @param array          $matches
  * @return string|null
  */
-function getPackageName(string $uri, \stdClass $composerJson = null): ?string
+function getPackageName(string $uri, \stdClass $composerJson = null)
 {
     $vendorDir = str_replace('/', '\/', getVendorDir($composerJson));
     preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches);

--- a/src/utils.php
+++ b/src/utils.php
@@ -137,7 +137,7 @@ function stripStringOverlap(string $a, string $b): string
  * Use for sorting an array of URIs by number of segments
  * in ascending order.
  *
- * @param array
+ * @param array $uriList
  * @return void
  */
 function sortUrisLevelOrder(&$uriList)
@@ -145,4 +145,48 @@ function sortUrisLevelOrder(&$uriList)
     usort($uriList, function ($a, $b) {
         return substr_count(Uri\parse($a)['path'], '/') - substr_count(Uri\parse($b)['path'], '/');
     });
+}
+
+/**
+ * Checks a document against the composer.json to see if it
+ * is a vendored document
+ *
+ * @param PhpDocument    $document
+ * @param \stdClass|null $composerJson
+ * @return bool
+ */
+function isVendored(PhpDocument $document, \stdClass $composerJson = null): bool
+{
+    $path = Uri\parse($document->getUri())['path'];
+    $vendorDir = getVendorDir($composerJson);
+    return strpos($path, "/$vendorDir/") !== false;
+}
+
+/**
+ * Check a given URI against the composer.json to see if it
+ * is a vendored URI
+ *
+ * @param \stdClass|null $composerJson
+ * @param string         $uri
+ * @param array          $matches
+ * @return int
+ */
+function uriInVendorDir(\stdClass $composerJson = null, string $uri, &$matches): int
+{
+    $vendorDir = str_replace('/', '\/', getVendorDir($composerJson));
+    return preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches);
+}
+
+/**
+ * Helper function to get the vendor directory from composer.json
+ * or default to 'vendor'
+ *
+ * @param \stdClass|null $composerJson
+ * @return string
+ */
+function getVendorDir(\stdClass $composerJson = null): string
+{
+    return isset($composerJson->config->{'vendor-dir'}) ?
+        $composerJson->config->{'vendor-dir'}
+        : 'vendor';
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -169,12 +169,13 @@ function isVendored(PhpDocument $document, \stdClass $composerJson = null): bool
  * @param \stdClass|null $composerJson
  * @param string         $uri
  * @param array          $matches
- * @return int
+ * @return string
  */
-function uriInVendorDir(\stdClass $composerJson = null, string $uri, &$matches): int
+function getPackageName(\stdClass $composerJson = null, string $uri): ?string
 {
     $vendorDir = str_replace('/', '\/', getVendorDir($composerJson));
-    return preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches);
+    preg_match("/\/$vendorDir\/([^\/]+\/[^\/]+)\//", $uri, $matches);
+    return isset($matches[1]) ? $matches[1] : null;
 }
 
 /**

--- a/src/utils.php
+++ b/src/utils.php
@@ -138,22 +138,11 @@ function stripStringOverlap(string $a, string $b): string
  * in ascending order.
  *
  * @param array
- * @return void
+ * @return array
  */
 function sortUrisLevelOrder(&$uriList)
 {
-    // Parse URIs so we are not continually parsing them while sorting
-    $parsedUriList = array_map(function ($uri) {
-        return Uri\parse($uri);
-    }, $uriList);
-
-    // Sort by number of slashes in parsed URI path, ascending
-    usort($parsedUriList, function ($a, $b) {
-        return substr_count($a['path'], '/') - substr_count($b['path'], '/');
+    usort($uriList, function ($a, $b) {
+        return substr_count(Uri\parse($a)['path'], '/') - substr_count(Uri\parse($b)['path'], '/');
     });
-
-    // Reassemble the URIs
-    $uriList = array_map(function ($parsedUri) {
-        return Uri\build($parsedUri);
-    }, $parsedUriList);
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -138,11 +138,22 @@ function stripStringOverlap(string $a, string $b): string
  * in ascending order.
  *
  * @param array
- * @return array
+ * @return void
  */
 function sortUrisLevelOrder(&$uriList)
 {
-    usort($uriList, function ($a, $b) {
-        return substr_count(Uri\parse($a)['path'], '/') - substr_count(Uri\parse($b)['path'], '/');
+    // Parse URIs so we are not continually parsing them while sorting
+    $parsedUriList = array_map(function ($uri) {
+        return Uri\parse($uri);
+    }, $uriList);
+
+    // Sort by number of slashes in parsed URI path, ascending
+    usort($parsedUriList, function ($a, $b) {
+        return substr_count($a['path'], '/') - substr_count($b['path'], '/');
     });
+
+    // Reassemble the URIs
+    $uriList = array_map(function ($parsedUri) {
+        return Uri\build($parsedUri);
+    }, $parsedUriList);
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -7,6 +7,7 @@ use Throwable;
 use InvalidArgumentException;
 use PhpParser\Node;
 use Sabre\Event\{Loop, Promise, EmitterInterface};
+use function Sabre\Uri\parse;
 
 /**
  * Transforms an absolute file path into a URI as used by the language server protocol.
@@ -130,4 +131,20 @@ function stripStringOverlap(string $a, string $b): string
         }
     }
     return $b;
+}
+
+/**
+ * Use for sorting an array of URIs by number of segments
+ * in ascending order.
+ *
+ * Example:
+ *     usort($uriList, 'LanguageServer\sortByLeastSlashes');
+ *
+ * @param $a string
+ * @param $b string
+ * @return integer
+ */
+function sortByLeastSlashes($a, $b)
+{
+    return substr_count(parse($a)['path'], '/') - substr_count(parse($b)['path'], '/');
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -138,7 +138,7 @@ function stripStringOverlap(string $a, string $b): string
  * in ascending order.
  *
  * @param array
- * @return array
+ * @return void
  */
 function sortUrisLevelOrder(&$uriList)
 {

--- a/src/utils.php
+++ b/src/utils.php
@@ -7,7 +7,7 @@ use Throwable;
 use InvalidArgumentException;
 use PhpParser\Node;
 use Sabre\Event\{Loop, Promise, EmitterInterface};
-use function Sabre\Uri\parse;
+use Sabre\Uri;
 
 /**
  * Transforms an absolute file path into a URI as used by the language server protocol.
@@ -137,14 +137,12 @@ function stripStringOverlap(string $a, string $b): string
  * Use for sorting an array of URIs by number of segments
  * in ascending order.
  *
- * Example:
- *     usort($uriList, 'LanguageServer\sortByLeastSlashes');
- *
- * @param $a string
- * @param $b string
- * @return integer
+ * @param array
+ * @return array
  */
-function sortByLeastSlashes($a, $b)
+function sortUrisLevelOrder(&$uriList)
 {
-    return substr_count(parse($a)['path'], '/') - substr_count(parse($b)['path'], '/');
+    usort($uriList, function ($a, $b) {
+        return substr_count(Uri\parse($a)['path'], '/') - substr_count(Uri\parse($b)['path'], '/');
+    });
 }

--- a/tests/PhpDocumentTest.php
+++ b/tests/PhpDocumentTest.php
@@ -42,18 +42,18 @@ class PhpDocumentTest extends TestCase
     public function testIsVendored()
     {
         $document = $this->createDocument('file:///dir/vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, $document->isVendored());
+        $this->assertEquals(true, \LanguageServer\isVendored($document));
 
         $document = $this->createDocument('file:///c:/dir/vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, $document->isVendored());
+        $this->assertEquals(true, \LanguageServer\isVendored($document));
 
         $document = $this->createDocument('file:///vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, $document->isVendored());
+        $this->assertEquals(true, \LanguageServer\isVendored($document));
 
         $document = $this->createDocument('file:///dir/vendor.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(false, $document->isVendored());
+        $this->assertEquals(false, \LanguageServer\isVendored($document));
 
         $document = $this->createDocument('file:///dir/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(false, $document->isVendored());
+        $this->assertEquals(false, \LanguageServer\isVendored($document));
     }
 }

--- a/tests/PhpDocumentTest.php
+++ b/tests/PhpDocumentTest.php
@@ -12,6 +12,7 @@ use LanguageServer\ContentRetriever\FileSystemContentRetriever;
 use LanguageServer\Protocol\{SymbolKind, Position, ClientCapabilities};
 use LanguageServer\Index\{Index, ProjectIndex, DependenciesIndex};
 use PhpParser\Node;
+use function LanguageServer\isVendored;
 
 class PhpDocumentTest extends TestCase
 {
@@ -42,18 +43,18 @@ class PhpDocumentTest extends TestCase
     public function testIsVendored()
     {
         $document = $this->createDocument('file:///dir/vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, \LanguageServer\isVendored($document));
+        $this->assertEquals(true, isVendored($document));
 
         $document = $this->createDocument('file:///c:/dir/vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, \LanguageServer\isVendored($document));
+        $this->assertEquals(true, isVendored($document));
 
         $document = $this->createDocument('file:///vendor/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(true, \LanguageServer\isVendored($document));
+        $this->assertEquals(true, isVendored($document));
 
         $document = $this->createDocument('file:///dir/vendor.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(false, \LanguageServer\isVendored($document));
+        $this->assertEquals(false, isVendored($document));
 
         $document = $this->createDocument('file:///dir/x.php', "<?php\n$\$a = new SomeClass;");
-        $this->assertEquals(false, \LanguageServer\isVendored($document));
+        $this->assertEquals(false, isVendored($document));
     }
 }


### PR DESCRIPTION
If not set, default to "vendor".

This PR also includes a bugfix for finding the appropriate composer.json and composer.lock files.

This PR does not address an existing issue with files that are included in composer.json via the "repositories" mechanism with a type of "package" mechanism, e.g.:

```json
        {
            "type": "package",
            "package": {
                "name": "ezyang/htmlpurifier",
                "version": "4.6.0",
                "dist": {
                    "url": "https://github.com/ezyang/HTMLPurifier/archive/v4.6.0.zip",
                    "type": "zip"
                }
            }
        }
```

These are not currently cached.  Those files are stored in the `[vendor]/composer/[some hash]/[packageName]-[packageVersion]` directory.  A future enhancement could cache these files as well.