### PR TITLE
DefinitionResolver fixes

### DIFF
--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -416,7 +416,7 @@ class DefinitionResolver
      * If the type could not be resolved, returns Types\Mixed.
      *
      * @param \PhpParser\Node\Expr $expr
-     * @return \phpDocumentor\Reflection\Type|\phpDocumentor\Type|null
+     * @return \phpDocumentor\Reflection\Type
      */
     public function resolveExpressionNodeToType(Node\Expr $expr): Type
     {
@@ -714,7 +714,7 @@ class DefinitionResolver
      * Returns null if the node does not have a type.
      *
      * @param Node $node
-     * @return \phpDocumentor\Type|null
+     * @return \phpDocumentor\Reflection\Type|null
      */
     public function getTypeFromNode(Node $node)
     {
@@ -732,6 +732,7 @@ class DefinitionResolver
                     }
                 }
             }
+            $type = null;
             if ($node->type !== null) {
                 // Use PHP7 return type hint
                 if (is_string($node->type)) {

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -12,7 +12,7 @@ use LanguageServer\Index\ReadableIndex;
 class DefinitionResolver
 {
     /**
-     * @var \LanguageServer\Index
+     * @var \LanguageServer\Index\ReadableIndex
      */
     private $index;
 
@@ -48,6 +48,7 @@ class DefinitionResolver
             // Properties and constants can have multiple declarations
             // Use the parent node (that includes the modifiers), but only render the requested declaration
             $child = $node;
+            /** @var Node */
             $node = $node->getAttribute('parentNode');
             $defLine = clone $node;
             $defLine->props = [$child];
@@ -363,7 +364,7 @@ class DefinitionResolver
      * Returns the assignment or parameter node where a variable was defined
      *
      * @param Node\Expr\Variable|Node\Expr\ClosureUse $var The variable access
-     * @return Node\Expr\Assign|Node\Param|Node\Expr\ClosureUse|null
+     * @return Node\Expr\Assign|Node\Expr\AssignOp|Node\Param|Node\Expr\ClosureUse|null
      */
     public static function resolveVariableToNode(Node\Expr $var)
     {
@@ -415,7 +416,7 @@ class DefinitionResolver
      * If the type could not be resolved, returns Types\Mixed.
      *
      * @param \PhpParser\Node\Expr $expr
-     * @return \phpDocumentor\Type
+     * @return \phpDocumentor\Reflection\Type|\phpDocumentor\Type|null
      */
     public function resolveExpressionNodeToType(Node\Expr $expr): Type
     {
@@ -539,7 +540,7 @@ class DefinitionResolver
             ]);
         }
         if (
-            $expr instanceof Node\Expr\InstanceOf_
+            $expr instanceof Node\Expr\Instanceof_
             || $expr instanceof Node\Expr\Cast\Bool_
             || $expr instanceof Node\Expr\BooleanNot
             || $expr instanceof Node\Expr\Empty_
@@ -559,19 +560,18 @@ class DefinitionResolver
             return new Types\Boolean;
         }
         if (
-            $expr instanceof Node\Expr\Concat
-            || $expr instanceof Node\Expr\Cast\String_
+            $expr instanceof Node\Expr\Cast\String_
             || $expr instanceof Node\Expr\BinaryOp\Concat
             || $expr instanceof Node\Expr\AssignOp\Concat
-            || $expr instanceof Node\Expr\Scalar\String_
-            || $expr instanceof Node\Expr\Scalar\Encapsed
-            || $expr instanceof Node\Expr\Scalar\EncapsedStringPart
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Class_
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Dir
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Function_
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Method
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Namespace_
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Trait_
+            || $expr instanceof Node\Scalar\String_
+            || $expr instanceof Node\Scalar\Encapsed
+            || $expr instanceof Node\Scalar\EncapsedStringPart
+            || $expr instanceof Node\Scalar\MagicConst\Class_
+            || $expr instanceof Node\Scalar\MagicConst\Dir
+            || $expr instanceof Node\Scalar\MagicConst\Function_
+            || $expr instanceof Node\Scalar\MagicConst\Method
+            || $expr instanceof Node\Scalar\MagicConst\Namespace_
+            || $expr instanceof Node\Scalar\MagicConst\Trait_
         ) {
             return new Types\String_;
         }
@@ -580,23 +580,35 @@ class DefinitionResolver
             || $expr instanceof Node\Expr\BinaryOp\Plus
             || $expr instanceof Node\Expr\BinaryOp\Pow
             || $expr instanceof Node\Expr\BinaryOp\Mul
-            || $expr instanceof Node\Expr\AssignOp\Minus
-            || $expr instanceof Node\Expr\AssignOp\Plus
-            || $expr instanceof Node\Expr\AssignOp\Pow
-            || $expr instanceof Node\Expr\AssignOp\Mul
         ) {
             if (
-                $this->resolveExpressionNodeToType($expr->left) instanceof Types\Integer_
-                && $this->resolveExpressionNodeToType($expr->right) instanceof Types\Integer_
+                $this->resolveExpressionNodeToType($expr->left) instanceof Types\Integer
+                && $this->resolveExpressionNodeToType($expr->right) instanceof Types\Integer
             ) {
                 return new Types\Integer;
             }
             return new Types\Float_;
         }
+
+        if (
+            $expr instanceof Node\Expr\AssignOp\Minus
+            || $expr instanceof Node\Expr\AssignOp\Plus
+            || $expr instanceof Node\Expr\AssignOp\Pow
+            || $expr instanceof Node\Expr\AssignOp\Mul
+        ) {
+            if (
+                $this->resolveExpressionNodeToType($expr->var) instanceof Types\Integer
+                && $this->resolveExpressionNodeToType($expr->expr) instanceof Types\Integer
+            ) {
+                return new Types\Integer;
+            }
+            return new Types\Float_;
+        }
+
         if (
             $expr instanceof Node\Scalar\LNumber
             || $expr instanceof Node\Expr\Cast\Int_
-            || $expr instanceof Node\Expr\Scalar\MagicConst\Line
+            || $expr instanceof Node\Scalar\MagicConst\Line
             || $expr instanceof Node\Expr\BinaryOp\Spaceship
             || $expr instanceof Node\Expr\BinaryOp\BitwiseAnd
             || $expr instanceof Node\Expr\BinaryOp\BitwiseOr
@@ -606,7 +618,7 @@ class DefinitionResolver
         }
         if (
             $expr instanceof Node\Expr\BinaryOp\Div
-            || $expr instanceof Node\Expr\DNumber
+            || $expr instanceof Node\Scalar\DNumber
             || $expr instanceof Node\Expr\Cast\Double
         ) {
             return new Types\Float_;
@@ -792,7 +804,7 @@ class DefinitionResolver
                 }
             } else if ($node instanceof Node\Const_) {
                 return $this->resolveExpressionNodeToType($node->value);
-            } else if ($node instanceof Node\Expr\Assign || $node instanceof Node\Expr\AssignOp) {
+            } else {
                 return $this->resolveExpressionNodeToType($node);
             }
             // TODO: read @property tags of class


### PR DESCRIPTION
By way of apology for the missing semicolon, here are some fixes to DefinitionResolver. More on the way, once I fix [a bug](https://github.com/vimeo/psalm/issues/99) I found in Psalm thanks to your use of null coalesce operators.