### PR TITLE
Ensure diagnostics are cleared on file deletion

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -253,6 +253,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             }
             if ($this->workspace === null) {
                 $this->workspace = new Server\Workspace(
+                    $this->client,
                     $this->projectIndex,
                     $dependenciesIndex,
                     $sourceIndex,

--- a/src/Protocol/FileEvent.php
+++ b/src/Protocol/FileEvent.php
@@ -20,4 +20,14 @@ class FileEvent
      * @var int
      */
     public $type;
+
+    /**
+     * @param string $uri
+     * @param int $type
+     */
+    public function __construct(string $uri, int $type)
+    {
+        $this->uri = $uri;
+        $this->type = $type;
+    }
 }

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -103,7 +103,8 @@ class Workspace
      * @param FileEvent[] $changes
      * @return void
      */
-    public function didChangeWatchedFiles(array $changes) : void {
+    public function didChangeWatchedFiles(array $changes)
+    {
         foreach ($changes as $change) {
             if ($change->type === FileChangeType::DELETED) {
                 $this->client->textDocument->publishDiagnostics($change->uri, []);

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -5,7 +5,15 @@ namespace LanguageServer\Server;
 
 use LanguageServer\{LanguageClient, Project, PhpDocumentLoader};
 use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
-use LanguageServer\Protocol\{SymbolInformation, SymbolDescriptor, ReferenceInformation, DependencyReference, Location};
+use LanguageServer\Protocol\{
+    FileChangeType,
+    FileEvent,
+    SymbolInformation,
+    SymbolDescriptor,
+    ReferenceInformation,
+    DependencyReference,
+    Location
+};
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
 use function LanguageServer\{waitForEvent, getPackageName};
@@ -15,6 +23,11 @@ use function LanguageServer\{waitForEvent, getPackageName};
  */
 class Workspace
 {
+    /**
+     * @var LanguageClient
+     */
+    public $client;
+
     /**
      * The symbol index for the workspace
      *
@@ -43,14 +56,16 @@ class Workspace
     public $documentLoader;
 
     /**
+     * @param LanguageClient    $client            LanguageClient instance used to signal updated results
      * @param ProjectIndex      $index             Index that is searched on a workspace/symbol request
      * @param DependenciesIndex $dependenciesIndex Index that is used on a workspace/xreferences request
      * @param DependenciesIndex $sourceIndex       Index that is used on a workspace/xreferences request
      * @param \stdClass         $composerLock      The parsed composer.lock of the project, if any
      * @param PhpDocumentLoader $documentLoader    PhpDocumentLoader instance to load documents
      */
-    public function __construct(ProjectIndex $index, DependenciesIndex $dependenciesIndex, Index $sourceIndex, \stdClass $composerLock = null, PhpDocumentLoader $documentLoader, \stdClass $composerJson = null)
+    public function __construct(LanguageClient $client, ProjectIndex $index, DependenciesIndex $dependenciesIndex, Index $sourceIndex, \stdClass $composerLock = null, PhpDocumentLoader $documentLoader, \stdClass $composerJson = null)
     {
+        $this->client = $client;
         $this->sourceIndex = $sourceIndex;
         $this->index = $index;
         $this->dependenciesIndex = $dependenciesIndex;
@@ -80,6 +95,20 @@ class Workspace
             }
             return $symbols;
         });
+    }
+
+    /**
+     * The watched files notification is sent from the client to the server when the client detects changes to files watched by the language client.
+     *
+     * @param FileEvent[] $changes
+     * @return void
+     */
+    public function didChangeWatchedFiles(array $changes) : void {
+        foreach ($changes as $change) {
+            if ($change->type === FileChangeType::DELETED) {
+                $this->client->textDocument->publishDiagnostics($change->uri, []);
+            }
+        }
     }
 
     /**

--- a/tests/Server/ServerTestCase.php
+++ b/tests/Server/ServerTestCase.php
@@ -54,7 +54,7 @@ abstract class ServerTestCase extends TestCase
         $client               = new LanguageClient(new MockProtocolStream, new MockProtocolStream);
         $this->documentLoader = new PhpDocumentLoader(new FileSystemContentRetriever, $projectIndex, $definitionResolver);
         $this->textDocument   = new Server\TextDocument($this->documentLoader, $definitionResolver, $client, $projectIndex);
-        $this->workspace      = new Server\Workspace($projectIndex, $dependenciesIndex, $sourceIndex, null, $this->documentLoader);
+        $this->workspace      = new Server\Workspace($client, $projectIndex, $dependenciesIndex, $sourceIndex, null, $this->documentLoader);
 
         $globalSymbolsUri    = pathToUri(realpath(__DIR__ . '/../../fixtures/global_symbols.php'));
         $globalReferencesUri = pathToUri(realpath(__DIR__ . '/../../fixtures/global_references.php'));

--- a/tests/Server/Workspace/DidChangeWatchedFilesTest.php
+++ b/tests/Server/Workspace/DidChangeWatchedFilesTest.php
@@ -22,12 +22,10 @@ class DidChangeWatchedFilesTest extends ServerTestCase
         $loader = new PhpDocumentLoader(new FileSystemContentRetriever(), $projectIndex, $definitionResolver);
         $workspace = new Server\Workspace($client, $projectIndex, $dependenciesIndex, $sourceIndex, null, $loader, null);
 
-        $fileEvent = new FileEvent();
-        $fileEvent->uri = 'my uri';
-        $fileEvent->type = FileChangeType::DELETED;
+        $fileEvent = new FileEvent('my uri', FileChangeType::DELETED);
 
         $isDiagnosticsCleared = false;
-        $writer->on('message', function (Message $message) use ($fileEvent, & $isDiagnosticsCleared) {
+        $writer->on('message', function (Message $message) use ($fileEvent, &$isDiagnosticsCleared) {
             if ($message->body->method === "textDocument/publishDiagnostics") {
                 $this->assertEquals($message->body->params->uri, $fileEvent->uri);
                 $this->assertEquals($message->body->params->diagnostics, []);

--- a/tests/Server/Workspace/DidChangeWatchedFilesTest.php
+++ b/tests/Server/Workspace/DidChangeWatchedFilesTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\Workspace;
+
+use LanguageServer\ContentRetriever\FileSystemContentRetriever;
+use LanguageServer\{DefinitionResolver, LanguageClient, PhpDocumentLoader, Server};
+use LanguageServer\Index\{DependenciesIndex, Index, ProjectIndex};
+use LanguageServer\Protocol\{FileChangeType, FileEvent, Message};
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\Tests\Server\ServerTestCase;
+use LanguageServer\Server\Workspace;
+use Sabre\Event\Loop;
+
+class DidChangeWatchedFilesTest extends ServerTestCase
+{
+    public function testDeletingFileClearsAllDiagnostics()
+    {
+        $client = new LanguageClient(new MockProtocolStream(), $writer = new MockProtocolStream());
+        $projectIndex = new ProjectIndex($sourceIndex = new Index(), $dependenciesIndex = new DependenciesIndex());
+        $definitionResolver = new DefinitionResolver($projectIndex);
+        $loader = new PhpDocumentLoader(new FileSystemContentRetriever(), $projectIndex, $definitionResolver);
+        $workspace = new Server\Workspace($client, $projectIndex, $dependenciesIndex, $sourceIndex, null, $loader, null);
+
+        $fileEvent = new FileEvent();
+        $fileEvent->uri = 'my uri';
+        $fileEvent->type = FileChangeType::DELETED;
+
+        $isDiagnosticsCleared = false;
+        $writer->on('message', function (Message $message) use ($fileEvent, & $isDiagnosticsCleared) {
+            if ($message->body->method === "textDocument/publishDiagnostics") {
+                $this->assertEquals($message->body->params->uri, $fileEvent->uri);
+                $this->assertEquals($message->body->params->diagnostics, []);
+                $isDiagnosticsCleared = true;
+            }
+        });
+
+        $workspace->didChangeWatchedFiles([$fileEvent]);
+        Loop\tick(true);
+
+        $this->assertTrue($isDiagnosticsCleared, "Deleting file should clear all diagnostics.");
+    }
+}


### PR DESCRIPTION
Previously, error diagnostics would not be cleared when a file was deleted while it was closed. This would result in lingering errors in the problems view that could only be cleared by reloading the language server. This fix addresses the issue by adding support for workspace/didChangeWatchedFiles and automatically clearing diagnostics for deleted files.

**Additional Notes / Questions**
* can add some more tests if it turns out that this is the correct approach, but wanted to get it out there for early feedback. 
* Is there a better way to test this? e.g. Currently the test is not resilient to the method name not matching the protocol name (test would succeed, but scenario would fail in real life)
* I discovered another couple issues while working through this which would be much easier to address after this fix:
  * language server only pulls in files during initialize, which means that files added from outside of the current editor instance are not being picked up. 
  * language server does not properly update definitions for deleted, changed, or moved files that are not opened in the editor.
* the change also requires a fix to vscode-php-intellisense to enable fileEvents in clientOptions. If there are options to include non *.php files in language server completions, this should be considered.
* I'm fairly certain PHP 7 optimizes empty array initializations, but need to double check on this. 