### PR TITLE
Enforce memory limit in phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,7 @@
             <directory>./src</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="memory_limit" value="256M"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
This will help highlight memory regressions, make it easier for newcomers to get started with the codebase w/o editing php.ini defaults (128M), and also keep things consistent between local and travis runs.