### PR TITLE
Fix formatting breakage (option 2)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpdocumentor/reflection-docblock": "^3.0",
         "sabre/event": "^5.0",
         "felixfbecker/advanced-json-rpc": "^2.0",
-        "squizlabs/php_codesniffer" : "^3.0",
+        "squizlabs/php_codesniffer" : "3.0.0RC3",
         "netresearch/jsonmapper": "^1.0",
         "webmozart/path-util": "^2.3",
         "webmozart/glob": "^4.1",


### PR DESCRIPTION
PHP_CodeSniffer 3.0 RC4 introduces a breaking change that removes PHPCS from the composer autoloader. This fix addresses the issue by locking to v3.0 RC3. See #322 for further discussion.

close #321