### PR TITLE
Fix crash when returning null instead of a Type when trying to infer node type

### DIFF
--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -813,7 +813,9 @@ class DefinitionResolver
             // Unknown
             return new Types\Mixed;
         }
-        return null;
+        // Return Types\Mixed in case nothing was found
+        // TODO: Find cases that don't match any rule and handle them'
+        return new Types\Mixed;
     }
 
     /**


### PR DESCRIPTION
Returns a Mixed instead of Null_, as the return type is pretty much unknown.