### PR TITLE
Allow getting type from define() node

### DIFF
--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -895,11 +895,16 @@ class DefinitionResolver
                 }
                 return (string)$class->namespacedName . '::' . $node->name;
             }
-        } else if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && strtolower((string)$node->name) === 'define') {
-            if (!isset($node->args[0]) || !($node->args[0]->value instanceof Node\Scalar\String_) || !isset($node->args[1])) {
-                return null;
-            }
+        } else if (
+            $node instanceof Node\Expr\FuncCall
+            && $node->name instanceof Node\Name
+            && strtolower((string)$node->name) === 'define'
+            && isset($node->args[0])
+            && $node->args[0]->value instanceof Node\Scalar\String_
+            && isset($node->args[1])
+        ) {
             return (string)$node->args[0]->value->value;
         }
+        return null;
     }
 }

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -725,6 +725,19 @@ class DefinitionResolver
      */
     public function getTypeFromNode(Node $node)
     {
+        if (
+            $node instanceof Node\Expr\FuncCall
+            && $node->name instanceof Node\Name
+            && strtolower((string)$node->name) === 'define'
+            && isset($node->args[0])
+            && $node->args[0]->value instanceof Node\Scalar\String_
+            && isset($node->args[1])
+        ) {
+            // constants with define() like
+            // define('TEST_DEFINE_CONSTANT', false);
+            return $this->resolveExpressionNodeToType($node->args[1]->value);
+        }
+
         if ($node instanceof Node\Param) {
             // Parameters
             $docBlock = $node->getAttribute('parentNode')->getAttribute('docBlock');
@@ -883,7 +896,7 @@ class DefinitionResolver
                 return (string)$class->namespacedName . '::' . $node->name;
             }
         } else if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && strtolower((string)$node->name) === 'define') {
-            if (!isset($node->args[0]) || !($node->args[0]->value instanceof Node\Scalar\String_)) {
+            if (!isset($node->args[0]) || !($node->args[0]->value instanceof Node\Scalar\String_) || !isset($node->args[1])) {
                 return null;
             }
             return (string)$node->args[0]->value->value;

--- a/src/Protocol/SymbolInformation.php
+++ b/src/Protocol/SymbolInformation.php
@@ -57,6 +57,7 @@ class SymbolInformation
             && strtolower((string)$node->name) === 'define'
             && isset($node->args[0])
             && $node->args[0]->value instanceof Node\Scalar\String_
+            && isset($node->args[1])
         ) {
             // constants with define() like
             // define('TEST_DEFINE_CONSTANT', false);
@@ -90,7 +91,7 @@ class SymbolInformation
         } else {
             return null;
         }
-        
+
         if (!isset($symbol->name)) {
             if ($node instanceof Node\Name) {
                 $symbol->name = (string)$node;

--- a/tests/DefinitionResolverTest.php
+++ b/tests/DefinitionResolverTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use LanguageServer\Index\Index;
+use LanguageServer\{DefinitionResolver, Parser};
+
+class DefinitionResolverTest extends TestCase
+{
+    public function testCreateDefinitionFromNode()
+    {
+        $parser = new Parser;
+        $stmts = $parser->parse("<?php\ndefine('TEST_DEFINE', true);");
+        $stmts[0]->setAttribute('ownerDocument', new MockPhpDocument);
+
+        $index = new Index;
+        $definitionResolver = new DefinitionResolver($index);
+        $def = $definitionResolver->createDefinitionFromNode($stmts[0], '\TEST_DEFINE');
+
+        $this->assertInstanceOf(\phpDocumentor\Reflection\Types\Boolean::class, $def->type);
+    }
+
+    public function testGetTypeFromNode()
+    {
+        $parser = new Parser;
+        $stmts = $parser->parse("<?php\ndefine('TEST_DEFINE', true);");
+        $stmts[0]->setAttribute('ownerDocument', new MockPhpDocument);
+
+        $index = new Index;
+        $definitionResolver = new DefinitionResolver($index);
+        $type = $definitionResolver->getTypeFromNode($stmts[0]);
+
+        $this->assertInstanceOf(\phpDocumentor\Reflection\Types\Boolean::class, $type);
+    }
+
+    public function testGetDefinedFqn()
+    {
+        // define('XXX') (only one argument) must not introduce a new symbol
+        $parser = new Parser;
+        $stmts = $parser->parse("<?php\ndefine('TEST_DEFINE');");
+        $stmts[0]->setAttribute('ownerDocument', new MockPhpDocument);
+
+        $index = new Index;
+        $definitionResolver = new DefinitionResolver($index);
+        $fqn = $definitionResolver->getDefinedFqn($stmts[0]);
+
+        $this->assertNull($fqn);
+    }
+}

--- a/tests/DefinitionResolverTest.php
+++ b/tests/DefinitionResolverTest.php
@@ -35,7 +35,7 @@ class DefinitionResolverTest extends TestCase
         $this->assertInstanceOf(\phpDocumentor\Reflection\Types\Boolean::class, $type);
     }
 
-    public function testGetDefinedFqn()
+    public function testGetDefinedFqnForIncompleteDefine()
     {
         // define('XXX') (only one argument) must not introduce a new symbol
         $parser = new Parser;
@@ -47,5 +47,18 @@ class DefinitionResolverTest extends TestCase
         $fqn = $definitionResolver->getDefinedFqn($stmts[0]);
 
         $this->assertNull($fqn);
+    }
+
+    public function testGetDefinedFqnForDefine()
+    {
+        $parser = new Parser;
+        $stmts = $parser->parse("<?php\ndefine('TEST_DEFINE', true);");
+        $stmts[0]->setAttribute('ownerDocument', new MockPhpDocument);
+
+        $index = new Index;
+        $definitionResolver = new DefinitionResolver($index);
+        $fqn = $definitionResolver->getDefinedFqn($stmts[0]);
+
+        $this->assertEquals('TEST_DEFINE', $fqn);
     }
 }

--- a/tests/MockPhpDocument.php
+++ b/tests/MockPhpDocument.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests;
+
+/**
+ * A fake document for tests
+ */
+class MockPhpDocument
+{
+    /**
+     * Returns fake uri
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        return 'file:///whatever';
+    }
+}


### PR DESCRIPTION
fixes #364 

`DefinitionResolver::getTypeFromNode()` was missing a case for `define()` function call nodes.
This caused the stubs file to contain lots of constants without an associated type.

Added the missing case and added checks to other parts concerning `define()` nodes so that incomplete defines (only one argument) are not resolved as constants.