### PR TITLE
Fix 'find references' for unused symbols

### DIFF
--- a/fixtures/global_symbols.php
+++ b/fixtures/global_symbols.php
@@ -105,3 +105,15 @@ class ChildClass extends TestClass {}
 define('TEST_DEFINE_CONSTANT', false);
 
 print TEST_DEFINE_CONSTANT ? 'true' : 'false';
+
+/**
+ * Neither this class nor its members are referenced anywhere
+ */
+class UnusedClass
+{
+    public $unusedProperty;
+
+    public function unusedMethod()
+    {        
+    }
+}

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -221,15 +221,18 @@ class TextDocument
                         return [];
                     }
                 }
-                $refDocuments = yield Promise\all(array_map(
-                    [$this->documentLoader, 'getOrLoad'],
-                    $this->index->getReferenceUris($fqn)
-                ));
-                foreach ($refDocuments as $document) {
-                    $refs = $document->getReferenceNodesByFqn($fqn);
-                    if ($refs !== null) {
-                        foreach ($refs as $ref) {
-                            $locations[] = Location::fromNode($ref);
+                $referenceUris = $this->index->getReferenceUris($fqn);
+                if (!empty($referenceUris)) {
+                    $refDocuments = yield Promise\all(array_map(
+                        [$this->documentLoader, 'getOrLoad'],
+                        $referenceUris
+                    ));
+                    foreach ($refDocuments as $document) {
+                        $refs = $document->getReferenceNodesByFqn($fqn);
+                        if ($refs !== null) {
+                            foreach ($refs as $ref) {
+                                $locations[] = Location::fromNode($ref);
+                            }
                         }
                     }
                 }

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -221,18 +221,15 @@ class TextDocument
                         return [];
                     }
                 }
-                $referenceUris = $this->index->getReferenceUris($fqn);
-                if (!empty($referenceUris)) {
-                    $refDocuments = yield Promise\all(array_map(
-                        [$this->documentLoader, 'getOrLoad'],
-                        $referenceUris
-                    ));
-                    foreach ($refDocuments as $document) {
-                        $refs = $document->getReferenceNodesByFqn($fqn);
-                        if ($refs !== null) {
-                            foreach ($refs as $ref) {
-                                $locations[] = Location::fromNode($ref);
-                            }
+                $refDocuments = yield Promise\all(array_map(
+                    [$this->documentLoader, 'getOrLoad'],
+                    $this->index->getReferenceUris($fqn)
+                ));
+                foreach ($refDocuments as $document) {
+                    $refs = $document->getReferenceNodesByFqn($fqn);
+                    if ($refs !== null) {
+                        foreach ($refs as $ref) {
+                            $locations[] = Location::fromNode($ref);
                         }
                     }
                 }

--- a/tests/Server/ServerTestCase.php
+++ b/tests/Server/ServerTestCase.php
@@ -85,6 +85,9 @@ abstract class ServerTestCase extends TestCase
             'TestClass::staticTestMethod()'          => new Location($globalSymbolsUri,    new Range(new Position(46,  4), new Position(49,   5))),
             'TestClass::testMethod()'                => new Location($globalSymbolsUri,    new Range(new Position(57,  4), new Position(60,   5))),
             'test_function()'                        => new Location($globalSymbolsUri,    new Range(new Position(78,  0), new Position(81,   1))),
+            'UnusedClass'                            => new Location($globalSymbolsUri,    new Range(new Position(111, 0), new Position(118,  1))),
+            'UnusedClass::unusedProperty'            => new Location($globalSymbolsUri,    new Range(new Position(113,11), new Position(113, 26))),
+            'UnusedClass::unusedMethod'              => new Location($globalSymbolsUri,    new Range(new Position(115, 4), new Position(117,  5))),
             'whatever()'                             => new Location($globalReferencesUri, new Range(new Position(21,  0), new Position(23,   1))),
 
             // Namespaced

--- a/tests/Server/TextDocument/References/GlobalTest.php
+++ b/tests/Server/TextDocument/References/GlobalTest.php
@@ -159,4 +159,43 @@ class GlobalTest extends ServerTestCase
         )->wait();
         $this->assertEquals($this->getReferenceLocations('TestClass'), $result);
     }
+
+    public function testReferencesForUnusedClass()
+    {
+        // class UnusedClass
+        // Get references for UnusedClass
+        $definition = $this->getDefinitionLocation('UnusedClass');
+        $result = $this->textDocument->references(
+            new ReferenceContext,
+            new TextDocumentIdentifier($definition->uri),
+            $definition->range->start
+        )->wait();
+        $this->assertEquals([], $result);
+    }
+
+    public function testReferencesForUnusedProperty()
+    {
+        // public $unusedProperty
+        // Get references for unusedProperty
+        $definition = $this->getDefinitionLocation('UnusedClass::unusedProperty');
+        $result = $this->textDocument->references(
+            new ReferenceContext,
+            new TextDocumentIdentifier($definition->uri),
+            $definition->range->start
+        )->wait();
+        $this->assertEquals([], $result);
+    }
+
+    public function testReferencesForUnusedMethod()
+    {
+        // public function unusedMethod()
+        // Get references for unusedMethod
+        $definition = $this->getDefinitionLocation('UnusedClass::unusedMethod');
+        $result = $this->textDocument->references(
+            new ReferenceContext,
+            new TextDocumentIdentifier($definition->uri),
+            $definition->range->start
+        )->wait();
+        $this->assertEquals([], $result);
+    }
 }

--- a/tests/Server/TextDocument/References/GlobalTest.php
+++ b/tests/Server/TextDocument/References/GlobalTest.php
@@ -164,11 +164,11 @@ class GlobalTest extends ServerTestCase
     {
         // class UnusedClass
         // Get references for UnusedClass
-        $definition = $this->getDefinitionLocation('UnusedClass');
+        $symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php'));
         $result = $this->textDocument->references(
             new ReferenceContext,
-            new TextDocumentIdentifier($definition->uri),
-            $definition->range->start
+            new TextDocumentIdentifier($symbolsUri),
+            new Position(111, 10)
         )->wait();
         $this->assertEquals([], $result);
     }
@@ -177,11 +177,11 @@ class GlobalTest extends ServerTestCase
     {
         // public $unusedProperty
         // Get references for unusedProperty
-        $definition = $this->getDefinitionLocation('UnusedClass::unusedProperty');
+        $symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php'));
         $result = $this->textDocument->references(
             new ReferenceContext,
-            new TextDocumentIdentifier($definition->uri),
-            $definition->range->start
+            new TextDocumentIdentifier($symbolsUri),
+            new Position(113, 18)
         )->wait();
         $this->assertEquals([], $result);
     }
@@ -190,11 +190,11 @@ class GlobalTest extends ServerTestCase
     {
         // public function unusedMethod()
         // Get references for unusedMethod
-        $definition = $this->getDefinitionLocation('UnusedClass::unusedMethod');
+        $symbolsUri = pathToUri(realpath(__DIR__ . '/../../../../fixtures/global_symbols.php'));
         $result = $this->textDocument->references(
             new ReferenceContext,
-            new TextDocumentIdentifier($definition->uri),
-            $definition->range->start
+            new TextDocumentIdentifier($symbolsUri),
+            new Position(115, 26)
         )->wait();
         $this->assertEquals([], $result);
     }

--- a/tests/Server/Workspace/SymbolTest.php
+++ b/tests/Server/Workspace/SymbolTest.php
@@ -27,6 +27,7 @@ class SymbolTest extends ServerTestCase
         // Request symbols
         $result = $this->workspace->symbol('')->wait();
         $referencesUri = pathToUri(realpath(__DIR__ . '/../../../fixtures/references.php'));
+
         // @codingStandardsIgnoreStart
         $this->assertEquals([
             new SymbolInformation('TestNamespace',      SymbolKind::NAMESPACE, new Location($referencesUri, new Range(new Position(2, 0), new Position(2, 24))), ''),
@@ -59,9 +60,12 @@ class SymbolTest extends ServerTestCase
             new SymbolInformation('test_function',          SymbolKind::FUNCTION,    $this->getDefinitionLocation('test_function()'),                              ''),
             new SymbolInformation('ChildClass',             SymbolKind::CLASS_,      $this->getDefinitionLocation('ChildClass'),                                   ''),
             new SymbolInformation('TEST_DEFINE_CONSTANT',   SymbolKind::CONSTANT,    $this->getDefinitionLocation('TEST_DEFINE_CONSTANT'),                         ''),
+            new SymbolInformation('UnusedClass',            SymbolKind::CLASS_,      $this->getDefinitionLocation('UnusedClass'),                                  ''),
+            new SymbolInformation('unusedProperty',         SymbolKind::PROPERTY,    $this->getDefinitionLocation('UnusedClass::unusedProperty'),                  'UnusedClass'),
+            new SymbolInformation('unusedMethod',           SymbolKind::METHOD,      $this->getDefinitionLocation('UnusedClass::unusedMethod'),                    'UnusedClass'),
             new SymbolInformation('whatever',               SymbolKind::FUNCTION,    $this->getDefinitionLocation('whatever()'),                                   ''),
 
-            new SymbolInformation('SecondTestNamespace',    SymbolKind::NAMESPACE,   $this->getDefinitionLocation('SecondTestNamespace'),                          '')
+            new SymbolInformation('SecondTestNamespace',    SymbolKind::NAMESPACE,   $this->getDefinitionLocation('SecondTestNamespace'),                          ''),
         ], $result);
         // @codingStandardsIgnoreEnd
     }


### PR DESCRIPTION
This fixes a bug where trying to execute `find references` on an unused symbol would cause the server to never return an answer, causing an infinite `waiting` in the references window.

The root of the problem is that `Promise\all` never fulfills itself when an empty array is passed.
I am not sure if this is expected behavior or a bug in the `sabre/event` lib...