### PR TITLE
Fix variable type from method return value, add tests

### DIFF
--- a/fixtures/completion/method_return_type.php
+++ b/fixtures/completion/method_return_type.php
@@ -1,0 +1,11 @@
+<?php
+
+class FooClass {
+    public function foo(): FooClass {
+        return $this;
+    }
+}
+
+$fc = new FooClass();
+$foo = $fc->foo();
+$foo->

--- a/fixtures/completion/static_method_return_type.php
+++ b/fixtures/completion/static_method_return_type.php
@@ -1,0 +1,12 @@
+<?php
+
+class FooClass {
+    public static function staticFoo(): FooClass {
+        return new FooClass();
+    }
+
+    public function bar() { }
+}
+
+$foo = FooClass::staticFoo();
+$foo->

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -623,6 +623,16 @@ class DefinitionResolver
             }
         }
 
+        // MEMBER CALL EXPRESSION
+        //   The type of the member call expression is the type of the method, so resolve the
+        //   type of the member access expression.
+        if ($expr instanceof Node\Expression\CallExpression && (
+            $expr->callableExpression instanceof Node\Expression\MemberAccessExpression ||
+            $expr->callableExpression instanceof Node\Expression\ScopedPropertyAccessExpression)
+        ) {
+            return $this->resolveExpressionNodeToType($expr->callableExpression);
+        }
+
         // MEMBER ACCESS EXPRESSION
         if ($expr instanceof Node\Expression\MemberAccessExpression) {
             if ($expr->memberName instanceof Node\Expression) {

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -623,9 +623,9 @@ class DefinitionResolver
             }
         }
 
-        // MEMBER CALL EXPRESSION
-        //   The type of the member call expression is the type of the method, so resolve the
-        //   type of the member access expression.
+        // MEMBER CALL EXPRESSION/SCOPED PROPERTY CALL EXPRESSION
+        //   The type of the member/scoped property call expression is the type of the method, so resolve the
+        //   type of the callable expression.
         if ($expr instanceof Node\Expression\CallExpression && (
             $expr->callableExpression instanceof Node\Expression\MemberAccessExpression ||
             $expr->callableExpression instanceof Node\Expression\ScopedPropertyAccessExpression)

--- a/tests/LanguageServerTest.php
+++ b/tests/LanguageServerTest.php
@@ -57,7 +57,7 @@ class LanguageServerTest extends TestCase
             if ($msg->body->method === 'window/logMessage' && $promise->state === Promise::PENDING) {
                 if ($msg->body->params->type === MessageType::ERROR) {
                     $promise->reject(new Exception($msg->body->params->message));
-                } else if (strpos($msg->body->params->message, 'All 27 PHP files parsed') !== false) {
+                } else if (preg_match('/All \d+ PHP files parsed/', $msg->body->params->message)) {
                     $promise->fulfill();
                 }
             }
@@ -103,7 +103,7 @@ class LanguageServerTest extends TestCase
                     if ($promise->state === Promise::PENDING) {
                         $promise->reject(new Exception($msg->body->params->message));
                     }
-                } else if (strpos($msg->body->params->message, 'All 27 PHP files parsed') !== false) {
+                } else if (preg_match('/All \d+ PHP files parsed/', $msg->body->params->message)) {
                     $promise->fulfill();
                 }
             }

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -499,6 +499,50 @@ class CompletionTest extends TestCase
         ], true), $items);
     }
 
+    public function testMethodReturnType()
+    {
+        $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/method_return_type.php');
+        $this->loader->open($completionUri, file_get_contents($completionUri));
+        $items = $this->textDocument->completion(
+            new TextDocumentIdentifier($completionUri),
+            new Position(10, 6)
+        )->wait();
+        $this->assertCompletionsListSubset(new CompletionList([
+            new CompletionItem(
+                'foo',
+                CompletionItemKind::METHOD,
+                '\FooClass',
+                null,
+                null,
+                null,
+                null,
+                null
+            )
+        ], true), $items);
+    }
+
+    public function testStaticMethodReturnType()
+    {
+        $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/static_method_return_type.php');
+        $this->loader->open($completionUri, file_get_contents($completionUri));
+        $items = $this->textDocument->completion(
+            new TextDocumentIdentifier($completionUri),
+            new Position(11, 6)
+        )->wait();
+        $this->assertCompletionsListSubset(new CompletionList([
+            new CompletionItem(
+                'bar',
+                CompletionItemKind::METHOD,
+                'mixed',
+                null,
+                null,
+                null,
+                null,
+                null
+            )
+        ], true), $items);
+    }
+
     private function assertCompletionsListSubset(CompletionList $subsetList, CompletionList $list)
     {
         foreach ($subsetList->items as $expectedItem) {

--- a/tests/Validation/ValidationTest.php
+++ b/tests/Validation/ValidationTest.php
@@ -137,8 +137,7 @@ class ValidationTest extends TestCase
                 } elseif ($propertyName === 'extends') {
                     $definition->$propertyName = $definition->$propertyName ?? [];
                 } elseif ($propertyName === 'type' && $definition->type !== null) {
-                    // Class info is not captured by json_encode. It's important for 'type'.
-                    $defsForAssert[$fqn]['type__class'] = get_class($definition->type);
+                    $defsForAssert[$fqn]['type__tostring'] = (string)$definition->type;
                 }
 
                 $defsForAssert[$fqn][$propertyName] = $definition->$propertyName;

--- a/tests/Validation/cases/WithReturnTypehints.php.expected.json
+++ b/tests/Validation/cases/WithReturnTypehints.php.expected.json
@@ -63,7 +63,7 @@
                 },
                 "containerName": "Fixtures\\Prophecy\\WithReturnTypehints"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\self",
             "type": {},
             "declarationLine": "public function getSelf(): self {",
             "documentation": null
@@ -82,7 +82,7 @@
                 },
                 "containerName": "Fixtures\\Prophecy\\WithReturnTypehints"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\String_",
+            "type__tostring": "string",
             "type": {},
             "declarationLine": "public function getName(): string {",
             "documentation": null
@@ -101,7 +101,7 @@
                 },
                 "containerName": "Fixtures\\Prophecy\\WithReturnTypehints"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\parent",
             "type": {},
             "declarationLine": "public function getParent(): parent {",
             "documentation": null

--- a/tests/Validation/cases/classDefinition1.php.expected.json
+++ b/tests/Validation/cases/classDefinition1.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "TestNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Integer",
+            "type__tostring": "int",
             "type": {},
             "declarationLine": "public $a;",
             "documentation": null

--- a/tests/Validation/cases/classProperty1.php.expected.json
+++ b/tests/Validation/cases/classProperty1.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "TestNamespace\\TestClass"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public $testProperty;",
             "documentation": null
@@ -77,7 +77,7 @@
                 },
                 "containerName": "TestNamespace\\TestClass"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function testMethod($testParameter)",
             "documentation": null

--- a/tests/Validation/cases/constants.php.expected.json
+++ b/tests/Validation/cases/constants.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public static function suite()",
             "documentation": null

--- a/tests/Validation/cases/constants2.php.expected.json
+++ b/tests/Validation/cases/constants2.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public static function suite()",
             "documentation": null

--- a/tests/Validation/cases/constants3.php.expected.json
+++ b/tests/Validation/cases/constants3.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public static function suite()",
             "documentation": null

--- a/tests/Validation/cases/constants4.php.expected.json
+++ b/tests/Validation/cases/constants4.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function suite()",
             "documentation": null

--- a/tests/Validation/cases/constants5.php.expected.json
+++ b/tests/Validation/cases/constants5.php.expected.json
@@ -55,7 +55,7 @@
                 },
                 "containerName": "MyNamespace\\Mbstring"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\MyNamespace\\PHP_INT_MAX",
             "type": {},
             "declarationLine": "const MB_CASE_FOLD = PHP_INT_MAX;",
             "documentation": null

--- a/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
+++ b/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
@@ -37,7 +37,7 @@
                 },
                 "containerName": "A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b ($a = MY_CONSTANT);",
             "documentation": null

--- a/tests/Validation/cases/magicConsts.php.expected.json
+++ b/tests/Validation/cases/magicConsts.php.expected.json
@@ -33,7 +33,7 @@
                 },
                 "containerName": "A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Array_",
+            "type__tostring": "\\__CLASS__[]",
             "type": {},
             "declarationLine": "private static $deprecationsTriggered;",
             "documentation": null

--- a/tests/Validation/cases/memberAccess1.php.expected.json
+++ b/tests/Validation/cases/memberAccess1.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "static function a() {",
             "documentation": null

--- a/tests/Validation/cases/memberAccess2.php.expected.json
+++ b/tests/Validation/cases/memberAccess2.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "static function a() {",
             "documentation": null

--- a/tests/Validation/cases/memberAccess3.php.expected.json
+++ b/tests/Validation/cases/memberAccess3.php.expected.json
@@ -73,7 +73,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public static function getInitializer(ClassLoader $loader)",
             "documentation": null

--- a/tests/Validation/cases/memberAccess4.php.expected.json
+++ b/tests/Validation/cases/memberAccess4.php.expected.json
@@ -64,7 +64,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function testRequest()",
             "documentation": null

--- a/tests/Validation/cases/memberAccess5.php.expected.json
+++ b/tests/Validation/cases/memberAccess5.php.expected.json
@@ -51,7 +51,7 @@
                 },
                 "containerName": "MyNamespace\\ParseErrorsTest"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function setUp()",
             "documentation": null

--- a/tests/Validation/cases/memberCall1.php.expected.json
+++ b/tests/Validation/cases/memberCall1.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\ParseErrorsTest"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function setAccount(AccountInterface $account)",
             "documentation": null

--- a/tests/Validation/cases/methodReturnType.php
+++ b/tests/Validation/cases/methodReturnType.php
@@ -1,0 +1,7 @@
+<?php
+
+class FooClass {
+    public function foo(): FooClass {
+        return $this;
+    }
+}

--- a/tests/Validation/cases/methodReturnType.php.expected.json
+++ b/tests/Validation/cases/methodReturnType.php.expected.json
@@ -1,41 +1,45 @@
 {
-    "references": [],
+    "references": {
+        "FooClass": [
+            "./methodReturnType.php"
+        ]
+    },
     "definitions": {
-        "A": {
-            "fqn": "A",
+        "FooClass": {
+            "fqn": "FooClass",
             "extends": [],
             "isGlobal": true,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
-                "name": "A",
+                "name": "FooClass",
                 "kind": 5,
                 "location": {
-                    "uri": "./arrayValueShouldBeBoolean.php"
+                    "uri": "./methodReturnType.php"
                 },
                 "containerName": ""
             },
             "type": null,
-            "declarationLine": "class A {",
+            "declarationLine": "class FooClass {",
             "documentation": null
         },
-        "A->foo": {
-            "fqn": "A->foo",
+        "FooClass->foo()": {
+            "fqn": "FooClass->foo()",
             "extends": [],
             "isGlobal": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
                 "name": "foo",
-                "kind": 7,
+                "kind": 6,
                 "location": {
-                    "uri": "./arrayValueShouldBeBoolean.php"
+                    "uri": "./methodReturnType.php"
                 },
-                "containerName": "A"
+                "containerName": "FooClass"
             },
-            "type__tostring": "string[]",
+            "type__tostring": "\\FooClass",
             "type": {},
-            "declarationLine": "protected $foo;",
+            "declarationLine": "public function foo(): FooClass {",
             "documentation": null
         }
     }

--- a/tests/Validation/cases/multipleNamespaces.php.expected.json
+++ b/tests/Validation/cases/multipleNamespaces.php.expected.json
@@ -64,7 +64,7 @@
                 },
                 "containerName": "MyNamespace1\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -121,7 +121,7 @@
                 },
                 "containerName": "MyNamespace2\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/multiplePreceedingComments.php.expected.json
+++ b/tests/Validation/cases/multiplePreceedingComments.php.expected.json
@@ -33,7 +33,7 @@
                 },
                 "containerName": "Foo"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\Iterator",
             "type": {},
             "declarationLine": "public function fn()",
             "documentation": "Foo"

--- a/tests/Validation/cases/nameToken.php.expected.json
+++ b/tests/Validation/cases/nameToken.php.expected.json
@@ -33,7 +33,7 @@
                 },
                 "containerName": "A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null

--- a/tests/Validation/cases/objectCreation.php.expected.json
+++ b/tests/Validation/cases/objectCreation.php.expected.json
@@ -55,7 +55,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/objectCreation2.php.expected.json
+++ b/tests/Validation/cases/objectCreation2.php.expected.json
@@ -76,7 +76,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/objectCreation3.php.expected.json
+++ b/tests/Validation/cases/objectCreation3.php.expected.json
@@ -37,7 +37,7 @@
                 },
                 "containerName": "A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/param1.php.expected.json
+++ b/tests/Validation/cases/param1.php.expected.json
@@ -37,7 +37,7 @@
                 },
                 "containerName": "MyNamespace"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function init(Hi $view)",
             "documentation": null

--- a/tests/Validation/cases/parent1.php.expected.json
+++ b/tests/Validation/cases/parent1.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -97,7 +97,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/parent3.php.expected.json
+++ b/tests/Validation/cases/parent3.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/propertyName1.php.expected.json
+++ b/tests/Validation/cases/propertyName1.php.expected.json
@@ -33,7 +33,7 @@
                 },
                 "containerName": "MyClass"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\String_",
+            "type__tostring": "string",
             "type": {},
             "declarationLine": "protected $mainPropertyName;",
             "documentation": "The name of the main property, or NULL if there is none."

--- a/tests/Validation/cases/propertyName2.php.expected.json
+++ b/tests/Validation/cases/propertyName2.php.expected.json
@@ -33,7 +33,7 @@
                 },
                 "containerName": "MyClass"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\String_",
+            "type__tostring": "string",
             "type": {},
             "declarationLine": "protected $mainPropertyName;",
             "documentation": "The name of the main property, or NULL if there is none."

--- a/tests/Validation/cases/returnType.php.expected.json
+++ b/tests/Validation/cases/returnType.php.expected.json
@@ -40,7 +40,7 @@
                 },
                 "containerName": "TestNamespace"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\TestNamespace\\TestClass",
             "type": {},
             "declarationLine": "function whatever(TestClass $param): TestClass2 {",
             "documentation": "Aute duis elit reprehenderit tempor cillum proident anim laborum eu laboris reprehenderit ea incididunt."

--- a/tests/Validation/cases/scopedPropertyAccess.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess.php.expected.json
@@ -58,7 +58,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "static function a() {",
             "documentation": null

--- a/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
@@ -40,7 +40,7 @@
                 },
                 "containerName": "A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\String_",
+            "type__tostring": "string",
             "type": {},
             "declarationLine": "static $a;",
             "documentation": null

--- a/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
@@ -46,7 +46,7 @@
                 },
                 "containerName": "TestClass"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Array_",
+            "type__tostring": "\\TestClass[]",
             "type": {},
             "declarationLine": "public static $testProperty;",
             "documentation": "Lorem excepteur officia sit anim velit veniam enim."

--- a/tests/Validation/cases/self1.php.expected.json
+++ b/tests/Validation/cases/self1.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/self2.php.expected.json
+++ b/tests/Validation/cases/self2.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/self3.php.expected.json
+++ b/tests/Validation/cases/self3.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/self4.php.expected.json
+++ b/tests/Validation/cases/self4.php.expected.json
@@ -64,7 +64,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public static function suite()",
             "documentation": null

--- a/tests/Validation/cases/self5.php.expected.json
+++ b/tests/Validation/cases/self5.php.expected.json
@@ -55,7 +55,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function typesProvider()",
             "documentation": null

--- a/tests/Validation/cases/static1.php.expected.json
+++ b/tests/Validation/cases/static1.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/static2.php.expected.json
+++ b/tests/Validation/cases/static2.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/static3.php.expected.json
+++ b/tests/Validation/cases/static3.php.expected.json
@@ -61,7 +61,7 @@
                 },
                 "containerName": "MyNamespace\\B"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function b() {",
             "documentation": null
@@ -100,7 +100,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/static4.php.expected.json
+++ b/tests/Validation/cases/static4.php.expected.json
@@ -60,7 +60,7 @@
                 },
                 "containerName": "MyNamespace\\A"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "function a () {",
             "documentation": null

--- a/tests/Validation/cases/staticMethodReturnType.php
+++ b/tests/Validation/cases/staticMethodReturnType.php
@@ -1,0 +1,9 @@
+<?php
+
+class FooClass {
+    public static function staticFoo(): FooClass {
+        return new FooClass();
+    }
+
+    public function bar() { }
+}

--- a/tests/Validation/cases/staticMethodReturnType.php.expected.json
+++ b/tests/Validation/cases/staticMethodReturnType.php.expected.json
@@ -1,60 +1,64 @@
 {
-    "references": [],
+    "references": {
+        "FooClass": [
+            "./staticMethodReturnType.php"
+        ]
+    },
     "definitions": {
-        "B": {
-            "fqn": "B",
+        "FooClass": {
+            "fqn": "FooClass",
             "extends": [],
             "isGlobal": true,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
-                "name": "B",
+                "name": "FooClass",
                 "kind": 5,
                 "location": {
-                    "uri": "./stringVariable.php"
+                    "uri": "./staticMethodReturnType.php"
                 },
                 "containerName": ""
             },
             "type": null,
-            "declarationLine": "class B",
+            "declarationLine": "class FooClass {",
             "documentation": null
         },
-        "B->hi": {
-            "fqn": "B->hi",
+        "FooClass::staticFoo()": {
+            "fqn": "FooClass::staticFoo()",
             "extends": [],
             "isGlobal": false,
-            "isStatic": false,
+            "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {
-                "name": "hi",
-                "kind": 7,
-                "location": {
-                    "uri": "./stringVariable.php"
-                },
-                "containerName": "B"
-            },
-            "type__tostring": "int",
-            "type": {},
-            "declarationLine": "public $hi;",
-            "documentation": null
-        },
-        "B->a()": {
-            "fqn": "B->a()",
-            "extends": [],
-            "isGlobal": false,
-            "isStatic": false,
-            "canBeInstantiated": false,
-            "symbolInformation": {
-                "name": "a",
+                "name": "staticFoo",
                 "kind": 6,
                 "location": {
-                    "uri": "./stringVariable.php"
+                    "uri": "./staticMethodReturnType.php"
                 },
-                "containerName": "B"
+                "containerName": "FooClass"
+            },
+            "type__tostring": "\\FooClass",
+            "type": {},
+            "declarationLine": "public static function staticFoo(): FooClass {",
+            "documentation": null
+        },
+        "FooClass->bar()": {
+            "fqn": "FooClass->bar()",
+            "extends": [],
+            "isGlobal": false,
+            "isStatic": false,
+            "canBeInstantiated": false,
+            "symbolInformation": {
+                "name": "bar",
+                "kind": 6,
+                "location": {
+                    "uri": "./staticMethodReturnType.php"
+                },
+                "containerName": "FooClass"
             },
             "type__tostring": "mixed",
             "type": {},
-            "declarationLine": "function a () {",
+            "declarationLine": "public function bar() { }",
             "documentation": null
         }
     }

--- a/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
+++ b/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
@@ -40,7 +40,7 @@
                 },
                 "containerName": "Foo"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Object_",
+            "type__tostring": "\\",
             "type": {},
             "declarationLine": "protected $bar;",
             "documentation": null
@@ -59,7 +59,7 @@
                 },
                 "containerName": "Foo"
             },
-            "type__class": "phpDocumentor\\Reflection\\Types\\Mixed",
+            "type__tostring": "mixed",
             "type": {},
             "declarationLine": "public function foo () {",
             "documentation": null


### PR DESCRIPTION
The change in DefinitionResolver correctly resolves the type of a method call expression.

Includes completion tests for a method and a static function. Also adds validation tests to check that the definitions of these methods are handled correctly (although this was correct before). I also modified the validation test to write the tostring value of the definition type, instead of just the class. This is much more useful.

Fixes #386 