### PR TITLE
install as a dev-dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ All classes are considered internal and are not subject to semver.
 The recommended installation method is through [Composer](https://getcomposer.org/).
 Simply run
 
-    composer require felixfbecker/language-server
+    composer require-dev felixfbecker/language-server
 
 and you will get the latest stable release and all dependencies.  
 Running `composer update` will update the server to the latest non-breaking version.


### PR DESCRIPTION
I am not totalle sure I understood the "install" chapter. please give me hints in case I missunderstood it and we should improve the docs in a different direction.

As I read this paragraphs the language-server is meant to be installed in every php project I develop locally. therefore I suppose to instruct the user to install it as a dev-dependency.

In case this paragraphs meaning is that you have to install the language server once locally and use this single instance for all php projects, I would recommend to reword this section.

thx for this great tool!