### PR TITLE
Exclude directory paths from file system search

### DIFF
--- a/src/FilesFinder/ClientFilesFinder.php
+++ b/src/FilesFinder/ClientFilesFinder.php
@@ -39,8 +39,7 @@ class ClientFilesFinder implements FilesFinder
             $uris = [];
             foreach ($textDocuments as $textDocument) {
                 $path = Uri\parse($textDocument->uri)['path'];
-                // Also exclude any directories that also match the glob pattern
-                if (Glob::match($path, $glob) && !is_dir($path)) {
+                if (Glob::match($path, $glob)) {
                     $uris[] = $textDocument->uri;
                 }
             }

--- a/src/FilesFinder/ClientFilesFinder.php
+++ b/src/FilesFinder/ClientFilesFinder.php
@@ -39,7 +39,8 @@ class ClientFilesFinder implements FilesFinder
             $uris = [];
             foreach ($textDocuments as $textDocument) {
                 $path = Uri\parse($textDocument->uri)['path'];
-                if (Glob::match($path, $glob)) {
+                // Also exclude any directories that also match the glob pattern
+                if (Glob::match($path, $glob) && !is_dir($path)) {
                     $uris[] = $textDocument->uri;
                 }
             }

--- a/src/FilesFinder/FileSystemFilesFinder.php
+++ b/src/FilesFinder/FileSystemFilesFinder.php
@@ -22,7 +22,11 @@ class FileSystemFilesFinder implements FilesFinder
         return coroutine(function () use ($glob) {
             $uris = [];
             foreach (new GlobIterator($glob) as $path) {
-                $uris[] = pathToUri($path);
+                // Exclude any directories that also match the glob pattern
+                if (!is_dir($path)) {
+                    $uris[] = pathToUri($path);
+                }
+
                 yield timeout();
             }
             return $uris;


### PR DESCRIPTION
Directories can also match the glob search pattern if their names end in ".php", which will cause a read error later since the ContentRetriever implementers are expecting files. This behavior can be reproduced by installing the Composer package "mtdowling/jmespath.php". 

As far as I know, the only way to fix this is to do an additional check to ensure the URI is not of a directory.

This resolves #306.