### PR TITLE
Improve CompletionProvider

### DIFF
--- a/fixtures/completion/inside_namespace_and_method.php
+++ b/fixtures/completion/inside_namespace_and_method.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace MyNamespace;
+
+class SomeClass
+{
+    public function someMethod()
+    {
+        tes
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,5 +7,7 @@
         <exclude name="PSR2.Namespaces.UseDeclaration.MultipleDeclarations"/>
         <exclude name="PSR2.ControlStructures.ElseIfDeclaration.NotAllowed"/>
         <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingBeforeClose"/>
+        <exclude name="Squiz.WhiteSpace.ControlStructureSpacing.SpacingAfterOpen"/>
     </rule>
 </ruleset>

--- a/src/CompletionProvider.php
+++ b/src/CompletionProvider.php
@@ -128,6 +128,7 @@ class CompletionProvider
         // This can be made much more performant if the tree follows specific invariants.
         $node = $doc->getNodeAtPosition($pos);
 
+        // Get the node at the position under the cursor
         $offset = $node === null ? -1 : $pos->toOffset($node->getFileContents());
         if (
             $node !== null
@@ -148,22 +149,31 @@ class CompletionProvider
             $node = $node->parent;
         }
 
+        // Inspect the type of expression under the cursor
+
         if ($node === null || $node instanceof Node\Statement\InlineHtml || $pos == new Position(0, 0)) {
+            // HTML, beginning of file
+
+            // Inside HTML and at the beginning of the file, propose <?php
             $item = new CompletionItem('<?php', CompletionItemKind::KEYWORD);
             $item->textEdit = new TextEdit(
                 new Range($pos, $pos),
                 stripStringOverlap($doc->getRange(new Range(new Position(0, 0), $pos)), '<?php')
             );
             $list->items[] = $item;
-        } /*
 
-        VARIABLES */
-        elseif (
-            $node instanceof Node\Expression\Variable &&
-            !(
-                $node->parent instanceof Node\Expression\ScopedPropertyAccessExpression &&
-                $node->parent->memberName === $node)
+        } elseif (
+            $node instanceof Node\Expression\Variable
+            && !(
+                $node->parent instanceof Node\Expression\ScopedPropertyAccessExpression
+                && $node->parent->memberName === $node
+            )
         ) {
+            // Variables
+            //
+            //    $|
+            //    $a|
+
             // Find variables, parameters and use statements in the scope
             $namePrefix = $node->getName() ?? '';
             foreach ($this->suggestVariablesAtNode($node, $namePrefix) as $var) {
@@ -178,23 +188,28 @@ class CompletionProvider
                 );
                 $list->items[] = $item;
             }
-        } /*
 
-        MEMBER ACCESS EXPRESSIONS
-           $a->c#
-           $a-># */
-        elseif ($node instanceof Node\Expression\MemberAccessExpression) {
+        } elseif ($node instanceof Node\Expression\MemberAccessExpression) {
+            // Member access expressions
+            //
+            //    $a->c|
+            //    $a->|
+
+            // Multiple prefixes for all possible types
             $prefixes = FqnUtilities\getFqnsFromType(
                 $this->definitionResolver->resolveExpressionNodeToType($node->dereferencableExpression)
             );
+
+            // Include parent classes
             $prefixes = $this->expandParentFqns($prefixes);
 
+            // Add the object access operator to only get members
             foreach ($prefixes as &$prefix) {
                 $prefix .= '->';
             }
-
             unset($prefix);
 
+            // Collect all definitions that match any of the prefixes
             foreach ($this->index->getDefinitions() as $fqn => $def) {
                 foreach ($prefixes as $prefix) {
                     if (substr($fqn, 0, strlen($prefix)) === $prefix && !$def->isGlobal) {
@@ -202,30 +217,35 @@ class CompletionProvider
                     }
                 }
             }
-        } /*
 
-        SCOPED PROPERTY ACCESS EXPRESSIONS
-            A\B\C::$a#
-            A\B\C::#
-            A\B\C::$#
-            A\B\C::foo#
-            TODO: $a::# */
-        elseif (
+        } elseif (
             ($scoped = $node->parent) instanceof Node\Expression\ScopedPropertyAccessExpression ||
             ($scoped = $node) instanceof Node\Expression\ScopedPropertyAccessExpression
         ) {
+            // Static class members and constants
+            //
+            //     A\B\C::$a|
+            //     A\B\C::|
+            //     A\B\C::$|
+            //     A\B\C::foo|
+            //
+            //     TODO: $a::|
+
+            // Resolve all possible types to FQNs
             $prefixes = FqnUtilities\getFqnsFromType(
                 $classType = $this->definitionResolver->resolveExpressionNodeToType($scoped->scopeResolutionQualifier)
             );
 
+            // Add parent classes
             $prefixes = $this->expandParentFqns($prefixes);
 
+            // Append :: operator to only get static members
             foreach ($prefixes as &$prefix) {
                 $prefix .= '::';
             }
-
             unset($prefix);
 
+            // Collect all definitions that match any of the prefixes
             foreach ($this->index->getDefinitions() as $fqn => $def) {
                 foreach ($prefixes as $prefix) {
                     if (substr(strtolower($fqn), 0, strlen($prefix)) === strtolower($prefix) && !$def->isGlobal) {
@@ -233,82 +253,123 @@ class CompletionProvider
                     }
                 }
             }
-        } elseif (ParserHelpers\isConstantFetch($node) ||
-            ($creation = $node->parent) instanceof Node\Expression\ObjectCreationExpression ||
-            (($creation = $node) instanceof Node\Expression\ObjectCreationExpression)) {
-            $class = isset($creation) ? $creation->classTypeDesignator : $node;
 
-            $prefix = $class instanceof Node\QualifiedName
-                ? (string)PhpParser\ResolvedName::buildName($class->nameParts, $class->getFileContents())
-                : $class->getText($node->getFileContents());
+        } elseif (
+            ParserHelpers\isConstantFetch($node)
+            // Creation gets set in case of an instantiation (`new` expression)
+            || ($creation = $node->parent) instanceof Node\Expression\ObjectCreationExpression
+            || (($creation = $node) instanceof Node\Expression\ObjectCreationExpression)
+        ) {
+            // Class instantiations, function calls, constant fetches, class names
+            //
+            //    new MyCl|
+            //    my_func|
+            //    MY_CONS|
+            //    MyCla|
 
-            $namespaceDefinition = $node->getNamespaceDefinition();
+            // The name Node under the cursor
+            $nameNode = isset($creation) ? $creation->classTypeDesignator : $node;
 
-            list($namespaceImportTable,,) = $node->getImportTablesForCurrentScope();
-            foreach ($namespaceImportTable as $alias => $name) {
-                $namespaceImportTable[$alias] = (string)$name;
+            /** The typed name */
+            $prefix = $nameNode instanceof Node\QualifiedName
+                ? (string)PhpParser\ResolvedName::buildName($nameNode->nameParts, $nameNode->getFileContents())
+                : $nameNode->getText($node->getFileContents());
+            $prefixLen = strlen($prefix);
+
+            /** Whether the prefix is qualified (contains at least one backslash) */
+            $isQualified = $nameNode instanceof Node\QualifiedName && $nameNode->isQualifiedName();
+
+            /** Whether the prefix is fully qualified (begins with a backslash) */
+            $isFullyQualified = $nameNode instanceof Node\QualifiedName && $nameNode->isFullyQualifiedName();
+
+            /** The closest NamespaceDefinition Node */
+            $namespaceNode = $node->getNamespaceDefinition();
+
+            /** @var string The name of the namespace */
+            $namespacedPrefix = null;
+            if ($namespaceNode) {
+                $namespacedPrefix = (string)PhpParser\ResolvedName::buildName($namespaceNode->name->nameParts, $node->getFileContents()) . '\\' . $prefix;
+                $namespacedPrefixLen = strlen($namespacedPrefix);
             }
 
-            foreach ($this->index->getDefinitions() as $fqn => $def) {
-                $fqnStartsWithPrefix = substr($fqn, 0, strlen($prefix)) === $prefix;
-                $fqnContainsPrefix = empty($prefix) || strpos($fqn, $prefix) !== false;
-                if (($def->canBeInstantiated || ($def->isGlobal && !isset($creation))) && $fqnContainsPrefix) {
-                    if ($namespaceDefinition !== null && $namespaceDefinition->name !== null) {
-                        $namespacePrefix = (string)PhpParser\ResolvedName::buildName($namespaceDefinition->name->nameParts, $node->getFileContents());
+            // Get the namespace use statements
+            // TODO: use function statements, use const statements
 
-                        $isAliased = false;
+            /** @var string[] $aliases A map from local alias to fully qualified name */
+            list($aliases,,) = $node->getImportTablesForCurrentScope();
 
-                        $isNotFullyQualified = !($class instanceof Node\QualifiedName) || !$class->isFullyQualifiedName();
-                        if ($isNotFullyQualified) {
-                            foreach ($namespaceImportTable as $alias => $name) {
-                                if (substr($fqn, 0, strlen($name)) === $name) {
-                                    $fqn = $alias;
-                                    $isAliased = true;
-                                    break;
-                                }
-                            }
-                        }
+            foreach ($aliases as $alias => $name) {
+                $aliases[$alias] = (string)$name;
+            }
 
-                        $prefixWithNamespace = $namespacePrefix . "\\" . $prefix;
-                        $fqnMatchesPrefixWithNamespace = substr($fqn, 0, strlen($prefixWithNamespace)) === $prefixWithNamespace;
-                        $isFullyQualifiedAndPrefixMatches = !$isNotFullyQualified && ($fqnStartsWithPrefix || $fqnMatchesPrefixWithNamespace);
-                        if (!$isFullyQualifiedAndPrefixMatches && !$isAliased) {
-                            if (!array_search($fqn, array_values($namespaceImportTable))) {
-                                if (empty($prefix)) {
-                                    $fqn = '\\' . $fqn;
-                                } elseif ($fqnMatchesPrefixWithNamespace) {
-                                    $fqn = substr($fqn, strlen($namespacePrefix) + 1);
-                                } else {
-                                    continue;
-                                }
-                            } else {
-                                continue;
-                            }
-                        }
-                    } elseif ($fqnStartsWithPrefix && $class instanceof Node\QualifiedName && $class->isFullyQualifiedName()) {
-                        $fqn = '\\' . $fqn;
+            // If there is a prefix that does not start with a slash, suggest `use`d symbols
+            if ($prefix && !$isFullyQualified) {
+                foreach ($aliases as $alias => $fqn) {
+                    // Suggest symbols that have been `use`d and match the prefix
+                    if (substr($alias, 0, $prefixLen) === $prefix && ($def = $this->index->getDefinition($fqn))) {
+                        $list->items[] = CompletionItem::fromDefinition($def);
                     }
+                }
+            }
 
+            // Suggest global symbols that either
+            //  - start with the current namespace + prefix, if the Name node is not fully qualified
+            //  - start with just the prefix, if the Name node is fully qualified
+            foreach ($this->index->getDefinitions() as $fqn => $def) {
+
+                $fqnStartsWithPrefix = substr($fqn, 0, $prefixLen) === $prefix;
+
+                if (
+                    // Exclude methods, properties etc.
+                    $def->isGlobal
+                    && (
+                        !$prefix
+                        || (
+                            // Either not qualified, but a matching prefix with global fallback
+                            ($def->roamed && !$isQualified && $fqnStartsWithPrefix)
+                            // Or not in a namespace or a fully qualified name or AND matching the prefix
+                            || ((!$namespaceNode || $isFullyQualified) && $fqnStartsWithPrefix)
+                            // Or in a namespace, not fully qualified and matching the prefix + current namespace
+                            || (
+                                $namespaceNode
+                                && !$isFullyQualified
+                                && substr($fqn, 0, $namespacedPrefixLen) === $namespacedPrefix
+                            )
+                        )
+                    )
+                    // Only suggest classes for `new`
+                    && (!isset($creation) || $def->canBeInstantiated)
+                ) {
                     $item = CompletionItem::fromDefinition($def);
-
-                    $item->insertText = $fqn;
+                    // Find the shortest name to reference the symbol
+                    if ($namespaceNode && ($alias = array_search($fqn, $aliases, true)) !== false) {
+                        // $alias is the name under which this definition is aliased in the current namespace
+                        $item->insertText = $alias;
+                    } else if ($namespaceNode && !($prefix && $isFullyQualified)) {
+                        // Insert the global FQN with leading backslash
+                        $item->insertText = '\\' . $fqn;
+                    } else {
+                        // Insert the FQN without leading backlash
+                        $item->insertText = $fqn;
+                    }
+                    // Don't insert the parenthesis for functions
+                    // TODO return a snippet and put the cursor inside
+                    if (substr($item->insertText, -2) === '()') {
+                        $item->insertText = substr($item->insertText, 0, -2);
+                    }
                     $list->items[] = $item;
                 }
             }
 
+            // If not a class instantiation, also suggest keywords
             if (!isset($creation)) {
                 foreach (self::KEYWORDS as $keyword) {
-                    $item = new CompletionItem($keyword, CompletionItemKind::KEYWORD);
-                    $item->insertText = $keyword . ' ';
-                    $list->items[] = $item;
+                    if (substr($keyword, 0, $prefixLen) === $prefix) {
+                        $item = new CompletionItem($keyword, CompletionItemKind::KEYWORD);
+                        $item->insertText = $keyword;
+                        $list->items[] = $item;
+                    }
                 }
-            }
-        } elseif (ParserHelpers\isConstantFetch($node)) {
-            $prefix = (string) ($node->getResolvedName() ?? PhpParser\ResolvedName::buildName($node->nameParts, $node->getFileContents()));
-            foreach (self::KEYWORDS as $keyword) {
-                $item = new CompletionItem($keyword, CompletionItemKind::KEYWORD);
-                $item->insertText = $keyword . ' ';
-                $list->items[] = $item;
             }
         }
 

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -45,6 +45,13 @@ class Definition
     public $isGlobal;
 
     /**
+     * True if this definition is affected by global namespace fallback (global function or global constant)
+     *
+     * @var bool
+     */
+    public $roamed;
+
+    /**
      * False for instance methods and properties
      *
      * @var bool

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -193,6 +193,16 @@ class DefinitionResolver
             ($node instanceof Node\ConstElement && $node->parent->parent instanceof Node\Statement\ConstDeclaration)
         );
 
+        // Definition is affected by global namespace fallback if it is a global constant or a global function
+        $def->roamed = (
+            $fqn !== null
+            && strpos($fqn, '\\') === false
+            && (
+                ($node instanceof Node\ConstElement && $node->parent->parent instanceof Node\Statement\ConstDeclaration)
+                || $node instanceof Node\Statement\FunctionDeclaration
+            )
+        );
+
         // Static methods and static property declarations
         $def->isStatic = (
             ($node instanceof Node\MethodDeclaration && $node->isStatic()) ||

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -69,6 +69,27 @@ class CompletionTest extends TestCase
         ], true), $items);
     }
 
+    public function testGlobalFunctionInsideNamespaceAndClass()
+    {
+        $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/inside_namespace_and_method.php');
+        $this->loader->open($completionUri, file_get_contents($completionUri));
+        $items = $this->textDocument->completion(
+            new TextDocumentIdentifier($completionUri),
+            new Position(8, 11)
+        )->wait();
+        $this->assertCompletionsListSubset(new CompletionList([
+            new CompletionItem(
+                'test_function',
+                CompletionItemKind::FUNCTION,
+                'void', // Return type
+                'Officia aliquip adipisicing et nulla et laboris dolore labore.',
+                null,
+                null,
+                '\test_function'
+            )
+        ], true), $items);
+    }
+
     public function testPropertyAndMethodWithoutPrefix()
     {
         $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/property.php');
@@ -234,10 +255,7 @@ class CompletionTest extends TestCase
                     'laboris commodo ad commodo velit mollit qui non officia id. Nulla duis veniam' . "\n" .
                     'veniam officia deserunt et non dolore mollit ea quis eiusmod sit non. Occaecat' . "\n" .
                     'consequat sunt culpa exercitation pariatur id reprehenderit nisi incididunt Lorem' . "\n" .
-                    'sint. Officia culpa pariatur laborum nostrud cupidatat consequat mollit.',
-                null,
-                null,
-                'TestClass'
+                    'sint. Officia culpa pariatur laborum nostrud cupidatat consequat mollit.'
             )
         ], true), $items);
     }
@@ -397,8 +415,8 @@ class CompletionTest extends TestCase
             new Position(2, 1)
         )->wait();
         $this->assertCompletionsListSubset(new CompletionList([
-            new CompletionItem('class', CompletionItemKind::KEYWORD, null, null, null, null, 'class '),
-            new CompletionItem('clone', CompletionItemKind::KEYWORD, null, null, null, null, 'clone ')
+            new CompletionItem('class', CompletionItemKind::KEYWORD, null, null, null, null, 'class'),
+            new CompletionItem('clone', CompletionItemKind::KEYWORD, null, null, null, null, 'clone')
         ], true), $items);
     }
 

--- a/tests/Validation/cases/WithReturnTypehints.php.expected.json
+++ b/tests/Validation/cases/WithReturnTypehints.php.expected.json
@@ -21,6 +21,7 @@
             "fqn": "Fixtures\\Prophecy",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -41,6 +42,7 @@
                 "Fixtures\\Prophecy\\EmptyClass"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -59,6 +61,7 @@
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getSelf()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -78,6 +81,7 @@
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getName()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -97,6 +101,7 @@
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getParent()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/anonymousClassMembersShouldNotBeSymbols.php.expected.json
+++ b/tests/Validation/cases/anonymousClassMembersShouldNotBeSymbols.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
+++ b/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "A->foo",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/caseStatement1.php.expected.json
+++ b/tests/Validation/cases/caseStatement1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/classDefinition1.php.expected.json
+++ b/tests/Validation/cases/classDefinition1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "TestNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "TestNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "TestNamespace\\A->a",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/classProperty1.php.expected.json
+++ b/tests/Validation/cases/classProperty1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "TestNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "TestNamespace\\TestClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "TestNamespace\\TestClass->testProperty",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -67,6 +70,7 @@
             "fqn": "TestNamespace\\TestClass->testMethod()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constants.php.expected.json
+++ b/tests/Validation/cases/constants.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constants2.php.expected.json
+++ b/tests/Validation/cases/constants2.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constants3.php.expected.json
+++ b/tests/Validation/cases/constants3.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constants4.php.expected.json
+++ b/tests/Validation/cases/constants4.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A->suite()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constants5.php.expected.json
+++ b/tests/Validation/cases/constants5.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "MyNamespace\\Mbstring",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -45,6 +47,7 @@
             "fqn": "MyNamespace\\Mbstring::MB_CASE_FOLD",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
+++ b/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "A->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/docBlocksOnNamespaceDefinition.php.expected.json
+++ b/tests/Validation/cases/docBlocksOnNamespaceDefinition.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/exceptions1.php.expected.json
+++ b/tests/Validation/cases/exceptions1.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/ifStatement1.php.expected.json
+++ b/tests/Validation/cases/ifStatement1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/interfaceProperty.php.expected.json
+++ b/tests/Validation/cases/interfaceProperty.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/magicConstantsShouldBeGlobal.php.expected.json
+++ b/tests/Validation/cases/magicConstantsShouldBeGlobal.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/magicConsts.php.expected.json
+++ b/tests/Validation/cases/magicConsts.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "A::$deprecationsTriggered",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberAccess1.php.expected.json
+++ b/tests/Validation/cases/memberAccess1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberAccess2.php.expected.json
+++ b/tests/Validation/cases/memberAccess2.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberAccess3.php.expected.json
+++ b/tests/Validation/cases/memberAccess3.php.expected.json
@@ -27,6 +27,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -45,6 +46,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -63,6 +65,7 @@
             "fqn": "MyNamespace\\A::getInitializer()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberAccess4.php.expected.json
+++ b/tests/Validation/cases/memberAccess4.php.expected.json
@@ -18,6 +18,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -36,6 +37,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -54,6 +56,7 @@
             "fqn": "MyNamespace\\A->testRequest()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberAccess5.php.expected.json
+++ b/tests/Validation/cases/memberAccess5.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "MyNamespace\\ParseErrorsTest",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -45,6 +47,7 @@
             "fqn": "MyNamespace\\ParseErrorsTest->setUp()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/memberCall1.php.expected.json
+++ b/tests/Validation/cases/memberCall1.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\ParseErrorsTest",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\ParseErrorsTest->setAccount()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/methodReturnType.php.expected.json
+++ b/tests/Validation/cases/methodReturnType.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "FooClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "FooClass->foo()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/multipleNamespaces.php.expected.json
+++ b/tests/Validation/cases/multipleNamespaces.php.expected.json
@@ -18,6 +18,7 @@
             "fqn": "MyNamespace1",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -36,6 +37,7 @@
             "fqn": "MyNamespace1\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -54,6 +56,7 @@
             "fqn": "MyNamespace1\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -73,6 +76,7 @@
             "fqn": "MyNamespace2",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -93,6 +97,7 @@
                 "MyNamespace2\\MyNamespace1\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -111,6 +116,7 @@
             "fqn": "MyNamespace2\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/multiplePreceedingComments.php.expected.json
+++ b/tests/Validation/cases/multiplePreceedingComments.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "Foo",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "Foo->fn()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/nameToken.php.expected.json
+++ b/tests/Validation/cases/nameToken.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "A->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/namespaces2.php.expected.json
+++ b/tests/Validation/cases/namespaces2.php.expected.json
@@ -18,6 +18,7 @@
             "fqn": "MyNamespace1",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/namespaces5.php.expected.json
+++ b/tests/Validation/cases/namespaces5.php.expected.json
@@ -27,6 +27,7 @@
             "fqn": "B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/namespaces6.php.expected.json
+++ b/tests/Validation/cases/namespaces6.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "A\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/namespaces8.php.expected.json
+++ b/tests/Validation/cases/namespaces8.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "LanguageServer\\Tests\\Utils",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/objectCreation.php.expected.json
+++ b/tests/Validation/cases/objectCreation.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -45,6 +47,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/objectCreation2.php.expected.json
+++ b/tests/Validation/cases/objectCreation2.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -66,6 +69,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/objectCreation3.php.expected.json
+++ b/tests/Validation/cases/objectCreation3.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/param1.php.expected.json
+++ b/tests/Validation/cases/param1.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "MyNamespace\\init()",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/parent1.php.expected.json
+++ b/tests/Validation/cases/parent1.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -69,6 +72,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -87,6 +91,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/parent3.php.expected.json
+++ b/tests/Validation/cases/parent3.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/propertyName1.php.expected.json
+++ b/tests/Validation/cases/propertyName1.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "MyClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "MyClass->mainPropertyName",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/propertyName2.php.expected.json
+++ b/tests/Validation/cases/propertyName2.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "MyClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "MyClass->mainPropertyName",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/returnType.php.expected.json
+++ b/tests/Validation/cases/returnType.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "TestNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "TestNamespace\\whatever()",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/scopedPropertyAccess.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -48,6 +50,7 @@
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/scopedPropertyAccess2.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess2.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "A::$a",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
@@ -18,6 +18,7 @@
             "fqn": "TestClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -36,6 +37,7 @@
             "fqn": "TestClass::$testProperty",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/self1.php.expected.json
+++ b/tests/Validation/cases/self1.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/self2.php.expected.json
+++ b/tests/Validation/cases/self2.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/self3.php.expected.json
+++ b/tests/Validation/cases/self3.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/self4.php.expected.json
+++ b/tests/Validation/cases/self4.php.expected.json
@@ -24,6 +24,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -42,6 +43,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -60,6 +62,7 @@
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/self5.php.expected.json
+++ b/tests/Validation/cases/self5.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "MyNamespace\\A",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -45,6 +47,7 @@
             "fqn": "MyNamespace\\A->typesProvider()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/static1.php.expected.json
+++ b/tests/Validation/cases/static1.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/static2.php.expected.json
+++ b/tests/Validation/cases/static2.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/static3.php.expected.json
+++ b/tests/Validation/cases/static3.php.expected.json
@@ -15,6 +15,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -33,6 +34,7 @@
             "fqn": "MyNamespace\\B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -51,6 +53,7 @@
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -72,6 +75,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -90,6 +94,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/static4.php.expected.json
+++ b/tests/Validation/cases/static4.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "MyNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -32,6 +33,7 @@
                 "MyNamespace\\B"
             ],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -50,6 +52,7 @@
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/staticMethodReturnType.php.expected.json
+++ b/tests/Validation/cases/staticMethodReturnType.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "FooClass",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -27,6 +28,7 @@
             "fqn": "FooClass::staticFoo()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -46,6 +48,7 @@
             "fqn": "FooClass->bar()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/stringVariable.php.expected.json
+++ b/tests/Validation/cases/stringVariable.php.expected.json
@@ -5,6 +5,7 @@
             "fqn": "B",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -23,6 +24,7 @@
             "fqn": "B->hi",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -42,6 +44,7 @@
             "fqn": "B->a()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/testQualifiedNameOutsideOfNamespace.php.expected.json
+++ b/tests/Validation/cases/testQualifiedNameOutsideOfNamespace.php.expected.json
@@ -9,6 +9,7 @@
             "fqn": "SomeNamespace",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {

--- a/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
+++ b/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
@@ -12,6 +12,7 @@
             "fqn": "Foo",
             "extends": [],
             "isGlobal": true,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
             "symbolInformation": {
@@ -30,6 +31,7 @@
             "fqn": "Foo->bar",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {
@@ -49,6 +51,7 @@
             "fqn": "Foo->foo()",
             "extends": [],
             "isGlobal": false,
+            "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
             "symbolInformation": {


### PR DESCRIPTION
- Better performance
  This moves stuff out of the `foreach` loop that doesn't have to be in the loop
- More documentation, clearer variable names
- Bring implementation closer to pre-tolerant parser implementation (for example, now always suggests aliases)
- Add `roamed` field to Definition for global namespace fallback for #380

/cc @roblourens 