### PR TITLE
Bump tolerant-php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "sabre/uri": "^2.0",
         "jetbrains/phpstorm-stubs": "dev-master",
         "composer/composer": "^1.3",
-        "Microsoft/tolerant-php-parser": "^0.0.2"
+        "Microsoft/tolerant-php-parser": "^0.0.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/tests/Validation/cases/static4.php.expected.json
+++ b/tests/Validation/cases/static4.php.expected.json
@@ -2,9 +2,6 @@
     "references": {
         "MyNamespace\\B": [
             "./static4.php"
-        ],
-        "static": [
-            "./static4.php"
         ]
     },
     "definitions": {


### PR DESCRIPTION
Shouldn't ^0.0.2 install 0.0.3?