### PR TITLE
Fix workspace/xreferences

### DIFF
--- a/src/Protocol/PackageDescriptor.php
+++ b/src/Protocol/PackageDescriptor.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Protocol;
+
+/**
+ * Uniquely identifies a Composer package
+ */
+class PackageDescriptor
+{
+    /**
+     * The package name
+     *
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @param string $name The package name
+     */
+    public function __construct(string $name = null)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Protocol/SymbolDescriptor.php
+++ b/src/Protocol/SymbolDescriptor.php
@@ -3,7 +3,10 @@ declare(strict_types = 1);
 
 namespace LanguageServer\Protocol;
 
-class SymbolDescriptor extends SymbolInformation
+/**
+ * Uniquely identifies a symbol
+ */
+class SymbolDescriptor
 {
     /**
      * The fully qualified structural element name, a globally unique identifier for the symbol.
@@ -13,19 +16,17 @@ class SymbolDescriptor extends SymbolInformation
     public $fqsen;
 
     /**
-     * A package from the composer.lock file or the contents of the composer.json
-     * Example: https://github.com/composer/composer/blob/master/composer.lock#L10
-     * Available fields may differ
+     * Identifies the Composer package the symbol is defined in (if any)
      *
-     * @var object|null
+     * @var PackageDescriptor|null
      */
     public $package;
 
     /**
-     * @param string $fqsen   The fully qualified structural element name, a globally unique identifier for the symbol.
-     * @param object $package A package from the composer.lock file or the contents of the composer.json
+     * @param string $fqsen              The fully qualified structural element name, a globally unique identifier for the symbol.
+     * @param PackageDescriptor $package Identifies the Composer package the symbol is defined in
      */
-    public function __construct(string $fqsen = null, $package = null)
+    public function __construct(string $fqsen = null, PackageDescriptor $package = null)
     {
         $this->fqsen = $fqsen;
         $this->package = $package;

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -396,7 +396,8 @@ class TextDocument
             }
             if (
                 $def === null
-                || ($def->symbolInformation !== null && Uri\parse($def->symbolInformation->location->uri)['scheme'] === 'phpstubs')
+                || $def->symbolInformation === null
+                || Uri\parse($def->symbolInformation->location->uri)['scheme'] === 'phpstubs'
             ) {
                 return [];
             }
@@ -406,8 +407,8 @@ class TextDocument
             if (!$packageName && $this->composerJson !== null) {
                 $packageName = $this->composerJson->name;
             }
-            $symbol = new SymbolDescriptor($def->fqn, new PackageDescriptor($packageName));
-            return [new SymbolLocationInformation($symbol, $symbol->location)];
+            $descriptor = new SymbolDescriptor($def->fqn, new PackageDescriptor($packageName));
+            return [new SymbolLocationInformation($descriptor, $def->symbolInformation->location)];
         });
     }
 }

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -27,7 +27,7 @@ use Microsoft\PhpParser\Node;
 use Sabre\Event\Promise;
 use Sabre\Uri;
 use function LanguageServer\{
-    isVendored, waitForEvent
+    isVendored, waitForEvent, getPackageName
 };
 use function Sabre\Event\coroutine;
 

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -148,32 +148,11 @@ class Workspace
             $refInfos = [];
             foreach ($refs as $uri => $fqns) {
                 foreach ($fqns as $fqn) {
-                    $def = $this->dependenciesIndex->getDefinition($fqn);
-                    if ($def === null) {
-                        $this->client->window->logMessage(MessageType::WARNING, "Reference $fqn not found in index");
-                        continue;
-                    }
-                    // Find out package name
-                    $packageName = getPackageName($def->symbolInformation->location->uri, $this->composerJson);
-                    $symbol = new SymbolDescriptor($fqn, new PackageDescriptor($packageName));
-                    // If there was no FQSEN provided, check if query attributes match
-                    if (!isset($query->fqsen)) {
-                        $matches = true;
-                        foreach (get_object_vars($query) as $prop => $val) {
-                            if ($query->$prop != $symbol->$prop) {
-                                $matches = false;
-                                break;
-                            }
-                        }
-                        if (!$matches) {
-                            continue;
-                        }
-                    }
                     $doc = yield $this->documentLoader->getOrLoad($uri);
                     foreach ($doc->getReferenceNodesByFqn($fqn) as $node) {
                         $refInfo = new ReferenceInformation;
                         $refInfo->reference = Location::fromNode($node);
-                        $refInfo->symbol = $symbol;
+                        $refInfo->symbol = $query;
                         $refInfos[] = $refInfo;
                     }
                 }

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -18,7 +18,7 @@ use LanguageServer\Protocol\{
 };
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
-use function LanguageServer\{waitForEvent, getPackageName};
+use function LanguageServer\waitForEvent;
 
 /**
  * Provides method handlers for all workspace/* methods

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -10,6 +10,7 @@ use LanguageServer\Protocol\{
     FileEvent,
     SymbolInformation,
     SymbolDescriptor,
+    PackageDescriptor,
     ReferenceInformation,
     DependencyReference,
     Location
@@ -147,19 +148,10 @@ class Workspace
             foreach ($refs as $uri => $fqns) {
                 foreach ($fqns as $fqn) {
                     $def = $this->dependenciesIndex->getDefinition($fqn);
-                    $symbol = new SymbolDescriptor;
                     $symbol->fqsen = $fqn;
-                    foreach (get_object_vars($def->symbolInformation) as $prop => $val) {
-                        $symbol->$prop = $val;
-                    }
                     // Find out package name
                     $packageName = getPackageName($def->symbolInformation->location->uri, $this->composerJson);
-                    foreach (array_merge($this->composerLock->packages, $this->composerLock->{'packages-dev'}) as $package) {
-                        if ($package->name === $packageName) {
-                            $symbol->package = $package;
-                            break;
-                        }
-                    }
+                    $symbol = new SymbolDescriptor($fqn, new PackageDescriptor($packageName));
                     // If there was no FQSEN provided, check if query attributes match
                     if (!isset($query->fqsen)) {
                         $matches = true;

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -13,7 +13,8 @@ use LanguageServer\Protocol\{
     PackageDescriptor,
     ReferenceInformation,
     DependencyReference,
-    Location
+    Location,
+    MessageType
 };
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
@@ -148,7 +149,10 @@ class Workspace
             foreach ($refs as $uri => $fqns) {
                 foreach ($fqns as $fqn) {
                     $def = $this->dependenciesIndex->getDefinition($fqn);
-                    $symbol->fqsen = $fqn;
+                    if ($def === null) {
+                        $this->client->window->logMessage(MessageType::WARNING, "Reference $fqn not found in index");
+                        continue;
+                    }
                     // Find out package name
                     $packageName = getPackageName($def->symbolInformation->location->uri, $this->composerJson);
                     $symbol = new SymbolDescriptor($fqn, new PackageDescriptor($packageName));


### PR DESCRIPTION
SymbolDescriptor and PackageDescriptor should only contain the minumum amount of properties needed. That means for SymbolDescriptor, only the FQSEN, and for PackageDescriptor only the package name. SymbolDescriptor should not inherit from SymbolInformation.