### PR TITLE
Exclude non-essential files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,10 @@
 /fixtures export-ignore
 /tests export-ignore
 /images export-ignore
+/validation export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/.gitmodules export-ignore
 /.dockerignore export-ignore
 /.travis.yml export-ignore
 /codecov.yml export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+* text=auto
+
+/.vscode export-ignore
+/fixtures export-ignore
+/tests export-ignore
+/images export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.dockerignore export-ignore
+/.travis.yml export-ignore
+/codecov.yml export-ignore
+/Dockerfile export-ignore
+/Performance.php export-ignore
+/php.ini export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore


### PR DESCRIPTION
[Exclude non-essential files in .gitattributes](https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/). This way users of this package doesn't have to download non-essential files such as the `tests` directory or the `.travis.yml` file.

Happy Hacktoberfest!