### PR TITLE
Fixes for unused variables

### DIFF
--- a/src/ClientHandler.php
+++ b/src/ClientHandler.php
@@ -71,7 +71,6 @@ class ClientHandler
      */
     public function notify(string $method, $params): Promise
     {
-        $id = $this->idGenerator->generate();
         return $this->protocolWriter->write(
             new Protocol\Message(
                 new AdvancedJsonRpc\Notification($method, (object)$params)

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -56,7 +56,8 @@ class ComposerScripts
                 $parts['scheme'] = 'phpstubs';
                 $uri = Uri\build($parts);
 
-                $document = new PhpDocument($uri, $content, $index, $parser, $docBlockFactory, $definitionResolver);
+                // Create a new document and add it to $index
+                new PhpDocument($uri, $content, $index, $parser, $docBlockFactory, $definitionResolver);
             }
 
             $index->setComplete();

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -151,7 +151,7 @@ class TextDocument
      * The document's truth now exists where the document's uri points to (e.g. if the document's uri is a file uri the
      * truth now exists on disk).
      *
-     * @param \LanguageServer\Protocol\TextDocumentItem $textDocument The document that was closed
+     * @param \LanguageServer\Protocol\TextDocumentIdentifier $textDocument The document that was closed
      * @return void
      */
     public function didClose(TextDocumentIdentifier $textDocument)

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -123,6 +123,7 @@ class Workspace
      */
     public function xreferences($query, array $files = null): Promise
     {
+        // TODO: $files is unused in the coroutine
         return coroutine(function () use ($query, $files) {
             if ($this->composerLock === null) {
                 return [];

--- a/src/TreeAnalyzer.php
+++ b/src/TreeAnalyzer.php
@@ -9,11 +9,18 @@ use phpDocumentor\Reflection\DocBlockFactory;
 use Sabre\Uri;
 use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Token;
 
 class TreeAnalyzer
 {
     /** @var PhpParser\Parser */
     private $parser;
+
+    /** @var DocBlockFactory */
+    private $docBlockFactory;
+
+    /** @var DefinitionResolver */
+    private $definitionResolver;
 
     /** @var Node\SourceFileNode */
     private $sourceFileNode;
@@ -57,7 +64,7 @@ class TreeAnalyzer
      * and transforms them into LSP Format
      *
      * @param Node|Token $node
-     * @return Diagnostic
+     * @return void
      */
     private function collectDiagnostics($node)
     {
@@ -203,7 +210,7 @@ class TreeAnalyzer
     }
 
     /**
-     * @return Definition
+     * @return Definition[]
      */
     public function getDefinitions()
     {

--- a/src/utils.php
+++ b/src/utils.php
@@ -148,9 +148,8 @@ function isVendored(PhpDocument $document, \stdClass $composerJson = null): bool
  * Check a given URI against the composer.json to see if it
  * is a vendored URI
  *
- * @param \stdClass|null $composerJson
  * @param string         $uri
- * @param array          $matches
+ * @param \stdClass|null $composerJson
  * @return string|null
  */
 function getPackageName(string $uri, \stdClass $composerJson = null)


### PR DESCRIPTION
The identifier doesn't need to be generated for a notification to the
client, since there's no response?

Add undeclared properties to TreeAnalyzer

Fix other bugs in phpdoc