### PR TITLE
Drop `composer run-script parse-stubs` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,7 @@ Run the tests with
 Lint with
 
     composer lint
+    
+The project parses PHPStorm's PHP stubs to get support for PHP builtins. It re-parses them as needed after Composer processes, but after some code changes (such as ones involving the index or parsing) you may have to explicitly re-parse them:
+
+    composer run-script parse-stubs

--- a/README.md
+++ b/README.md
@@ -191,9 +191,6 @@ Clone the repository and run
     composer install
 
 to install dependencies.
-Then parse the stubs with
-
-    composer run-script parse-stubs
 
 Run the tests with 
 


### PR DESCRIPTION
As the parse-stubs step is done automatically by `composer install` since https://github.com/felixfbecker/php-language-server/commit/34d3d2030dabc29bd919d0ea795bcb8d994228de, we no longer need to explicitly instruct people to do it.