### PR TITLE
refactor(index): rename isGlobal to isMember

### DIFF
--- a/src/CompletionProvider.php
+++ b/src/CompletionProvider.php
@@ -210,7 +210,7 @@ class CompletionProvider
             // Collect all definitions that match any of the prefixes
             foreach ($this->index->getDefinitions() as $fqn => $def) {
                 foreach ($prefixes as $prefix) {
-                    if (substr($fqn, 0, strlen($prefix)) === $prefix && !$def->isGlobal) {
+                    if (substr($fqn, 0, strlen($prefix)) === $prefix && $def->isMember) {
                         $list->items[] = CompletionItem::fromDefinition($def);
                     }
                 }
@@ -243,7 +243,7 @@ class CompletionProvider
             // Collect all definitions that match any of the prefixes
             foreach ($this->index->getDefinitions() as $fqn => $def) {
                 foreach ($prefixes as $prefix) {
-                    if (substr(strtolower($fqn), 0, strlen($prefix)) === strtolower($prefix) && !$def->isGlobal) {
+                    if (substr(strtolower($fqn), 0, strlen($prefix)) === strtolower($prefix) && $def->isMember) {
                         $list->items[] = CompletionItem::fromDefinition($def);
                     }
                 }
@@ -316,7 +316,7 @@ class CompletionProvider
 
                 if (
                     // Exclude methods, properties etc.
-                    $def->isGlobal
+                    !$def->isMember
                     && (
                         !$prefix
                         || (

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -39,12 +39,13 @@ class Definition
     public $extends;
 
     /**
-     * Only true for classes, interfaces, traits, functions and non-class constants
+     * False for classes, interfaces, traits, functions and non-class constants
+     * True for methods, properties and class constants
      * This is so methods and properties are not suggested in the global scope
      *
      * @var bool
      */
-    public $isGlobal;
+    public $isMember;
 
     /**
      * True if this definition is affected by global namespace fallback (global function or global constant)

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -181,7 +181,7 @@ class DefinitionResolver
         );
 
         // Interfaces, classes, traits, namespaces, functions, and global const elements
-        $def->isGlobal = (
+        $def->isMember = !(
             $node instanceof PhpParser\ClassLike ||
 
             ($node instanceof Node\Statement\NamespaceDefinition && $node->name !== null) ||

--- a/tests/Validation/cases/WithReturnTypehints.php.expected.json
+++ b/tests/Validation/cases/WithReturnTypehints.php.expected.json
@@ -20,7 +20,7 @@
         "Fixtures\\Prophecy": {
             "fqn": "Fixtures\\Prophecy",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -41,7 +41,7 @@
             "extends": [
                 "Fixtures\\Prophecy\\EmptyClass"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -60,7 +60,7 @@
         "Fixtures\\Prophecy\\WithReturnTypehints->getSelf()": {
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getSelf()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -80,7 +80,7 @@
         "Fixtures\\Prophecy\\WithReturnTypehints->getName()": {
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getName()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -100,7 +100,7 @@
         "Fixtures\\Prophecy\\WithReturnTypehints->getParent()": {
             "fqn": "Fixtures\\Prophecy\\WithReturnTypehints->getParent()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/anonymousClassMembersShouldNotBeSymbols.php.expected.json
+++ b/tests/Validation/cases/anonymousClassMembersShouldNotBeSymbols.php.expected.json
@@ -4,7 +4,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
+++ b/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
@@ -4,7 +4,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -23,7 +23,7 @@
         "A->foo": {
             "fqn": "A->foo",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/caseStatement1.php.expected.json
+++ b/tests/Validation/cases/caseStatement1.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/classDefinition1.php.expected.json
+++ b/tests/Validation/cases/classDefinition1.php.expected.json
@@ -11,7 +11,7 @@
         "TestNamespace": {
             "fqn": "TestNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "TestNamespace\\A": {
             "fqn": "TestNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "TestNamespace\\A->a": {
             "fqn": "TestNamespace\\A->a",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/classProperty1.php.expected.json
+++ b/tests/Validation/cases/classProperty1.php.expected.json
@@ -11,7 +11,7 @@
         "TestNamespace": {
             "fqn": "TestNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "TestNamespace\\TestClass": {
             "fqn": "TestNamespace\\TestClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "TestNamespace\\TestClass->testProperty": {
             "fqn": "TestNamespace\\TestClass->testProperty",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -69,7 +69,7 @@
         "TestNamespace\\TestClass->testMethod()": {
             "fqn": "TestNamespace\\TestClass->testMethod()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constants.php.expected.json
+++ b/tests/Validation/cases/constants.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::suite()": {
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constants2.php.expected.json
+++ b/tests/Validation/cases/constants2.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::suite()": {
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constants3.php.expected.json
+++ b/tests/Validation/cases/constants3.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::suite()": {
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constants4.php.expected.json
+++ b/tests/Validation/cases/constants4.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A->suite()": {
             "fqn": "MyNamespace\\A->suite()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constants5.php.expected.json
+++ b/tests/Validation/cases/constants5.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "MyNamespace\\Mbstring": {
             "fqn": "MyNamespace\\Mbstring",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -46,7 +46,7 @@
         "MyNamespace\\Mbstring::MB_CASE_FOLD": {
             "fqn": "MyNamespace\\Mbstring::MB_CASE_FOLD",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
+++ b/tests/Validation/cases/constantsInFunctionParamDefault.php.expected.json
@@ -8,7 +8,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "A->b()": {
             "fqn": "A->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/docBlocksOnNamespaceDefinition.php.expected.json
+++ b/tests/Validation/cases/docBlocksOnNamespaceDefinition.php.expected.json
@@ -4,7 +4,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/exceptions1.php.expected.json
+++ b/tests/Validation/cases/exceptions1.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/ifStatement1.php.expected.json
+++ b/tests/Validation/cases/ifStatement1.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/interfaceProperty.php.expected.json
+++ b/tests/Validation/cases/interfaceProperty.php.expected.json
@@ -4,7 +4,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/magicConstantsShouldBeGlobal.php.expected.json
+++ b/tests/Validation/cases/magicConstantsShouldBeGlobal.php.expected.json
@@ -11,7 +11,7 @@
         "B": {
             "fqn": "B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/magicConsts.php.expected.json
+++ b/tests/Validation/cases/magicConsts.php.expected.json
@@ -8,7 +8,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -27,7 +27,7 @@
         "A::$deprecationsTriggered": {
             "fqn": "A::$deprecationsTriggered",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberAccess1.php.expected.json
+++ b/tests/Validation/cases/memberAccess1.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::a()": {
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberAccess2.php.expected.json
+++ b/tests/Validation/cases/memberAccess2.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::a()": {
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberAccess3.php.expected.json
+++ b/tests/Validation/cases/memberAccess3.php.expected.json
@@ -26,7 +26,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -45,7 +45,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -64,7 +64,7 @@
         "MyNamespace\\A::getInitializer()": {
             "fqn": "MyNamespace\\A::getInitializer()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberAccess4.php.expected.json
+++ b/tests/Validation/cases/memberAccess4.php.expected.json
@@ -17,7 +17,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -36,7 +36,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -55,7 +55,7 @@
         "MyNamespace\\A->testRequest()": {
             "fqn": "MyNamespace\\A->testRequest()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberAccess5.php.expected.json
+++ b/tests/Validation/cases/memberAccess5.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "MyNamespace\\ParseErrorsTest": {
             "fqn": "MyNamespace\\ParseErrorsTest",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -46,7 +46,7 @@
         "MyNamespace\\ParseErrorsTest->setUp()": {
             "fqn": "MyNamespace\\ParseErrorsTest->setUp()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/memberCall1.php.expected.json
+++ b/tests/Validation/cases/memberCall1.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\ParseErrorsTest": {
             "fqn": "MyNamespace\\ParseErrorsTest",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\ParseErrorsTest->setAccount()": {
             "fqn": "MyNamespace\\ParseErrorsTest->setAccount()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/methodReturnType.php.expected.json
+++ b/tests/Validation/cases/methodReturnType.php.expected.json
@@ -8,7 +8,7 @@
         "FooClass": {
             "fqn": "FooClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -27,7 +27,7 @@
         "FooClass->foo()": {
             "fqn": "FooClass->foo()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/multipleNamespaces.php.expected.json
+++ b/tests/Validation/cases/multipleNamespaces.php.expected.json
@@ -17,7 +17,7 @@
         "MyNamespace1": {
             "fqn": "MyNamespace1",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -36,7 +36,7 @@
         "MyNamespace1\\B": {
             "fqn": "MyNamespace1\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -55,7 +55,7 @@
         "MyNamespace1\\B->b()": {
             "fqn": "MyNamespace1\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -75,7 +75,7 @@
         "MyNamespace2": {
             "fqn": "MyNamespace2",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -96,7 +96,7 @@
             "extends": [
                 "MyNamespace2\\MyNamespace1\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -115,7 +115,7 @@
         "MyNamespace2\\A->a()": {
             "fqn": "MyNamespace2\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/multiplePreceedingComments.php.expected.json
+++ b/tests/Validation/cases/multiplePreceedingComments.php.expected.json
@@ -4,7 +4,7 @@
         "Foo": {
             "fqn": "Foo",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -23,7 +23,7 @@
         "Foo->fn()": {
             "fqn": "Foo->fn()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/nameToken.php.expected.json
+++ b/tests/Validation/cases/nameToken.php.expected.json
@@ -4,7 +4,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -23,7 +23,7 @@
         "A->b()": {
             "fqn": "A->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/namespaces2.php.expected.json
+++ b/tests/Validation/cases/namespaces2.php.expected.json
@@ -17,7 +17,7 @@
         "MyNamespace1": {
             "fqn": "MyNamespace1",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/namespaces5.php.expected.json
+++ b/tests/Validation/cases/namespaces5.php.expected.json
@@ -26,7 +26,7 @@
         "B": {
             "fqn": "B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/namespaces6.php.expected.json
+++ b/tests/Validation/cases/namespaces6.php.expected.json
@@ -4,7 +4,7 @@
         "A\\B": {
             "fqn": "A\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/namespaces8.php.expected.json
+++ b/tests/Validation/cases/namespaces8.php.expected.json
@@ -14,7 +14,7 @@
         "LanguageServer\\Tests\\Utils": {
             "fqn": "LanguageServer\\Tests\\Utils",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/objectCreation.php.expected.json
+++ b/tests/Validation/cases/objectCreation.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -46,7 +46,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/objectCreation2.php.expected.json
+++ b/tests/Validation/cases/objectCreation2.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -68,7 +68,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/objectCreation3.php.expected.json
+++ b/tests/Validation/cases/objectCreation3.php.expected.json
@@ -8,7 +8,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -27,7 +27,7 @@
         "A->a()": {
             "fqn": "A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/param1.php.expected.json
+++ b/tests/Validation/cases/param1.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "MyNamespace\\init()": {
             "fqn": "MyNamespace\\init()",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/parent1.php.expected.json
+++ b/tests/Validation/cases/parent1.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -71,7 +71,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -90,7 +90,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/parent3.php.expected.json
+++ b/tests/Validation/cases/parent3.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/propertyName1.php.expected.json
+++ b/tests/Validation/cases/propertyName1.php.expected.json
@@ -4,7 +4,7 @@
         "MyClass": {
             "fqn": "MyClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -23,7 +23,7 @@
         "MyClass->mainPropertyName": {
             "fqn": "MyClass->mainPropertyName",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/propertyName2.php.expected.json
+++ b/tests/Validation/cases/propertyName2.php.expected.json
@@ -4,7 +4,7 @@
         "MyClass": {
             "fqn": "MyClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -23,7 +23,7 @@
         "MyClass->mainPropertyName": {
             "fqn": "MyClass->mainPropertyName",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/returnType.php.expected.json
+++ b/tests/Validation/cases/returnType.php.expected.json
@@ -11,7 +11,7 @@
         "TestNamespace": {
             "fqn": "TestNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "TestNamespace\\whatever()": {
             "fqn": "TestNamespace\\whatever()",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/scopedPropertyAccess.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess.php.expected.json
@@ -11,7 +11,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -30,7 +30,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -49,7 +49,7 @@
         "MyNamespace\\A::a()": {
             "fqn": "MyNamespace\\A::a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/scopedPropertyAccess2.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess2.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess3.php.expected.json
@@ -11,7 +11,7 @@
         "A": {
             "fqn": "A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -30,7 +30,7 @@
         "A::$a": {
             "fqn": "A::$a",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
+++ b/tests/Validation/cases/scopedPropertyAccess5.php.expected.json
@@ -17,7 +17,7 @@
         "TestClass": {
             "fqn": "TestClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -36,7 +36,7 @@
         "TestClass::$testProperty": {
             "fqn": "TestClass::$testProperty",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/self1.php.expected.json
+++ b/tests/Validation/cases/self1.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/self2.php.expected.json
+++ b/tests/Validation/cases/self2.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/self3.php.expected.json
+++ b/tests/Validation/cases/self3.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/self4.php.expected.json
+++ b/tests/Validation/cases/self4.php.expected.json
@@ -23,7 +23,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -42,7 +42,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -61,7 +61,7 @@
         "MyNamespace\\A::suite()": {
             "fqn": "MyNamespace\\A::suite()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/self5.php.expected.json
+++ b/tests/Validation/cases/self5.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -27,7 +27,7 @@
         "MyNamespace\\A": {
             "fqn": "MyNamespace\\A",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -46,7 +46,7 @@
         "MyNamespace\\A->typesProvider()": {
             "fqn": "MyNamespace\\A->typesProvider()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/static1.php.expected.json
+++ b/tests/Validation/cases/static1.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/static2.php.expected.json
+++ b/tests/Validation/cases/static2.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/static3.php.expected.json
+++ b/tests/Validation/cases/static3.php.expected.json
@@ -14,7 +14,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -33,7 +33,7 @@
         "MyNamespace\\B": {
             "fqn": "MyNamespace\\B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -52,7 +52,7 @@
         "MyNamespace\\B->b()": {
             "fqn": "MyNamespace\\B->b()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -74,7 +74,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -93,7 +93,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/static4.php.expected.json
+++ b/tests/Validation/cases/static4.php.expected.json
@@ -8,7 +8,7 @@
         "MyNamespace": {
             "fqn": "MyNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -29,7 +29,7 @@
             "extends": [
                 "MyNamespace\\B"
             ],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -48,7 +48,7 @@
         "MyNamespace\\A->a()": {
             "fqn": "MyNamespace\\A->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/staticMethodReturnType.php.expected.json
+++ b/tests/Validation/cases/staticMethodReturnType.php.expected.json
@@ -8,7 +8,7 @@
         "FooClass": {
             "fqn": "FooClass",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -27,7 +27,7 @@
         "FooClass::staticFoo()": {
             "fqn": "FooClass::staticFoo()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": true,
             "canBeInstantiated": false,
@@ -47,7 +47,7 @@
         "FooClass->bar()": {
             "fqn": "FooClass->bar()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/stringVariable.php.expected.json
+++ b/tests/Validation/cases/stringVariable.php.expected.json
@@ -8,7 +8,7 @@
         "B": {
             "fqn": "B",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -27,7 +27,7 @@
         "B->hi": {
             "fqn": "B->hi",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -47,7 +47,7 @@
         "B->a()": {
             "fqn": "B->a()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/testQualifiedNameOutsideOfNamespace.php.expected.json
+++ b/tests/Validation/cases/testQualifiedNameOutsideOfNamespace.php.expected.json
@@ -8,7 +8,7 @@
         "SomeNamespace": {
             "fqn": "SomeNamespace",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,

--- a/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
+++ b/tests/Validation/cases/verifyFqsenOnClassProperty.php.expected.json
@@ -11,7 +11,7 @@
         "Foo": {
             "fqn": "Foo",
             "extends": [],
-            "isGlobal": true,
+            "isMember": false,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": true,
@@ -30,7 +30,7 @@
         "Foo->bar": {
             "fqn": "Foo->bar",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,
@@ -50,7 +50,7 @@
         "Foo->foo()": {
             "fqn": "Foo->foo()",
             "extends": [],
-            "isGlobal": false,
+            "isMember": true,
             "roamed": false,
             "isStatic": false,
             "canBeInstantiated": false,


### PR DESCRIPTION
isGlobal was confusing because a non-member can be considered global vs namespaced