### PR TITLE
Update checking of $this usage to only error in static methods.

### DIFF
--- a/fixtures/diagnostics/errors/this_in_function.php
+++ b/fixtures/diagnostics/errors/this_in_function.php
@@ -1,6 +1,0 @@
-<?php
-
-function foo()
-{
-    return $this;
-}

--- a/fixtures/diagnostics/errors/this_in_root.php
+++ b/fixtures/diagnostics/errors/this_in_root.php
@@ -1,3 +1,0 @@
-<?php
-
-echo $this;

--- a/src/TreeAnalyzer.php
+++ b/src/TreeAnalyzer.php
@@ -99,11 +99,9 @@ class TreeAnalyzer
             // Find the first ancestor that's a class method. Return an error
             // if there is none, or if the method is static.
             $method = $node->getFirstAncestor(Node\MethodDeclaration::class);
-            if ($method === null || $method->isStatic()) {
+            if ($method->isStatic()) {
                 $this->diagnostics[] = new Diagnostic(
-                    $method === null
-                        ? "\$this can only be used in an object context."
-                        : "\$this can not be used in static methods.",
+                    "\$this can not be used in static methods.",
                     Range::fromNode($node),
                     null,
                     DiagnosticSeverity::ERROR,

--- a/tests/Diagnostics/InvalidThisUsageTest.php
+++ b/tests/Diagnostics/InvalidThisUsageTest.php
@@ -71,42 +71,6 @@ class InvalidThisUsageTest extends TestCase
         );
     }
 
-    public function testThisInFunctionProducesError()
-    {
-        $diagnostics = $this->collectDiagnostics(
-            __DIR__ . '/../../fixtures/diagnostics/errors/this_in_function.php'
-        );
-
-        $this->assertCount(1, $diagnostics);
-        $this->assertDiagnostic(
-            $diagnostics[0],
-            '$this can only be used in an object context.',
-            DiagnosticSeverity::ERROR,
-            new Range(
-                new Position(4, 11),
-                new Position(4, 16)
-            )
-        );
-    }
-
-    public function testThisInRoot()
-    {
-        $diagnostics = $this->collectDiagnostics(
-            __DIR__ . '/../../fixtures/diagnostics/errors/this_in_root.php'
-        );
-
-        $this->assertCount(1, $diagnostics);
-        $this->assertDiagnostic(
-            $diagnostics[0],
-            '$this can only be used in an object context.',
-            DiagnosticSeverity::ERROR,
-            new Range(
-                new Position(2, 5),
-                new Position(2, 10)
-            )
-        );
-    }
-
     public function testThisInMethodProducesNoError()
     {
         $diagnostics = $this->collectDiagnostics(


### PR DESCRIPTION
This rolls back a few of the changes in #528 to address the concerns in #536. It will now only produce an error in static methods, and leave usages of $this in the root and in closures alone.