### PR TITLE
Foreach completion

### DIFF
--- a/fixtures/completion/foreach.php
+++ b/fixtures/completion/foreach.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Foo;
+
+class Bar {
+    public $foo;
+
+    /** @return Bar[] */
+    public function test() { }
+}
+
+$bar = new Bar();
+$bars = $bar->test();
+$array1 = [new Bar(), new \stdClass()];
+$array2 = ['foo' => $bar, $bar];
+$array3 = ['foo' => $bar, 'baz' => $bar];
+
+foreach ($bars as $value) {
+    $v
+    $value->
+}
+
+foreach ($array1 as $key => $value) {
+    $
+}
+
+foreach ($array2 as $key => $value) {
+    $
+}
+
+foreach ($array3 as $key => $value) {
+    $
+}
+
+foreach ($array1 as list($z, $y)) {
+    $
+}
+
+foreach ($bar->test() as $value) {
+    $
+}

--- a/fixtures/completion/foreach.php
+++ b/fixtures/completion/foreach.php
@@ -32,10 +32,6 @@ foreach ($array3 as $key => $value) {
     $
 }
 
-foreach ($array1 as list($z, $y)) {
-    $
-}
-
 foreach ($bar->test() as $value) {
     $
 }

--- a/src/CompletionProvider.php
+++ b/src/CompletionProvider.php
@@ -486,6 +486,14 @@ class CompletionProvider
 
         if ($this->isAssignmentToVariableWithPrefix($node, $namePrefix)) {
             $vars[] = $node->leftOperand;
+        } elseif ($node instanceof Node\ForeachKey || $node instanceof Node\ForeachValue) {
+            foreach ($node->getDescendantNodes() as $descendantNode) {
+                if ($descendantNode instanceof Node\Expression\Variable
+                    && ($namePrefix === '' || strpos($descendantNode->getName(), $namePrefix) !== false)
+                ) {
+                    $vars[] = $descendantNode;
+                }
+            }
         } else {
             // Get all descendent variables, then filter to ones that start with $namePrefix.
             // Avoiding closure usage in tight loop

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -1097,14 +1097,14 @@ class DefinitionResolver
             return new Types\Mixed_;
         }
 
-        // FOREACH KEY
+        // FOREACH KEY/VARIABLE
         if ($node instanceof Node\ForeachKey || $node->parent instanceof Node\ForeachKey) {
             $foreach = $node->getFirstAncestor(Node\Statement\ForeachStatement::class);
             $collectionType = $this->resolveExpressionNodeToType($foreach->forEachCollectionName);
             if ($collectionType instanceof Types\Array_) {
                 return $collectionType->getKeyType();
             }
-            return new Types\Compound([new Types\String_(), new Types\Integer()]);
+            return new Types\Mixed_();
         }
 
         // FOREACH VALUE

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -568,6 +568,20 @@ class DefinitionResolver
                 }
                 break;
             }
+
+            // If we get to a ForeachStatement, check the keys and values
+            if ($n instanceof Node\Statement\ForeachStatement) {
+                if ($n->foreachKey && $n->foreachKey->expression->getName() === $name) {
+                    return $n->foreachKey;
+                }
+                if ($n->foreachValue
+                    && $n->foreachValue->expression instanceof Node\Expression\Variable
+                    && $n->foreachValue->expression->getName() === $name
+                ) {
+                    return $n->foreachValue;
+                }
+            }
+
             // Check each previous sibling node for a variable assignment to that variable
             while (($prevSibling = $n->getPreviousSibling()) !== null && $n = $prevSibling) {
                 if ($n instanceof Node\Statement\ExpressionStatement) {
@@ -618,6 +632,9 @@ class DefinitionResolver
             $defNode = $this->resolveVariableToNode($expr);
             if ($defNode instanceof Node\Expression\AssignmentExpression || $defNode instanceof Node\UseVariableName) {
                 return $this->resolveExpressionNodeToType($defNode);
+            }
+            if ($defNode instanceof Node\ForeachKey || $defNode instanceof Node\ForeachValue) {
+                return $this->getTypeFromNode($defNode);
             }
             if ($defNode instanceof Node\Parameter) {
                 return $this->getTypeFromNode($defNode);
@@ -900,7 +917,7 @@ class DefinitionResolver
                     $keyTypes[] = $item->elementKey ? $this->resolveExpressionNodeToType($item->elementKey) : new Types\Integer;
                 }
             }
-            $valueTypes = array_unique($keyTypes);
+            $valueTypes = array_unique($valueTypes);
             $keyTypes = array_unique($keyTypes);
             if (empty($valueTypes)) {
                 $valueType = null;
@@ -1078,6 +1095,25 @@ class DefinitionResolver
             }
             // Unknown return type
             return new Types\Mixed_;
+        }
+
+        // FOREACH KEY
+        if ($node instanceof Node\ForeachKey || $node->parent instanceof Node\ForeachKey) {
+            $foreach = $node->getFirstAncestor(Node\Statement\ForeachStatement::class);
+            $collectionType = $this->resolveExpressionNodeToType($foreach->forEachCollectionName);
+            if ($collectionType instanceof Types\Array_) {
+                return $collectionType->getKeyType();
+            }
+            return new Types\Compound([new Types\String_(), new Types\Integer()]);
+        }
+
+        // FOREACH VALUE
+        if ($node instanceof Node\ForeachValue || $node->getFirstAncestor(Node\ForeachValue::class)) {
+            $foreach = $node->getFirstAncestor(Node\Statement\ForeachStatement::class);
+            $collectionType = $this->resolveExpressionNodeToType($foreach->forEachCollectionName);
+            if ($collectionType instanceof Types\Array_) {
+                return $collectionType->getValueType();
+            }
         }
 
         // PROPERTIES, CONSTS, CLASS CONSTS, ASSIGNMENT EXPRESSIONS

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -1107,8 +1107,10 @@ class DefinitionResolver
             return new Types\Mixed_();
         }
 
-        // FOREACH VALUE
-        if ($node instanceof Node\ForeachValue || $node->getFirstAncestor(Node\ForeachValue::class)) {
+        // FOREACH VALUE/VARIABLE
+        if ($node instanceof Node\ForeachValue
+            || ($node instanceof Node\Expression\Variable && $node->parent instanceof Node\ForeachValue)
+        ) {
             $foreach = $node->getFirstAncestor(Node\Statement\ForeachStatement::class);
             $collectionType = $this->resolveExpressionNodeToType($foreach->forEachCollectionName);
             if ($collectionType instanceof Types\Array_) {

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -337,6 +337,7 @@ class TextDocument
             if ($def === null) {
                 return new Hover([], $range);
             }
+            $contents = [];
             if ($def->declarationLine) {
                 $contents[] = new MarkedString('php', "<?php\n" . $def->declarationLine);
             }

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -676,33 +676,8 @@ class CompletionTest extends TestCase
                     ),
                 ]
             ],
-            'foreach with list()' => [
-                new Position(35, 5),
-                [
-                    new CompletionItem(
-                        '$z',
-                        CompletionItemKind::VARIABLE,
-                        '\\Foo\\Bar|\\stdClass',
-                        null,
-                        null,
-                        null,
-                        null,
-                        new TextEdit(new Range(new Position(35, 5), new Position(35, 5)), 'z')
-                    ),
-                    new CompletionItem(
-                        '$y',
-                        CompletionItemKind::VARIABLE,
-                        '\\Foo\\Bar|\\stdClass',
-                        null,
-                        null,
-                        null,
-                        null,
-                        new TextEdit(new Range(new Position(35, 5), new Position(35, 5)), 'y')
-                    ),
-                ]
-            ],
             'foreach function call' => [
-                new Position(39, 5),
+                new Position(35, 5),
                 [
                     new CompletionItem(
                         '$value',
@@ -712,7 +687,7 @@ class CompletionTest extends TestCase
                         null,
                         null,
                         null,
-                        new TextEdit(new Range(new Position(39, 5), new Position(39, 5)), 'value')
+                        new TextEdit(new Range(new Position(35, 5), new Position(35, 5)), 'value')
                     ),
                 ]
             ],

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -554,6 +554,171 @@ class CompletionTest extends TestCase
         ], true), $items);
     }
 
+    /**
+     * @dataProvider foreachProvider
+     */
+    public function testForeach(Position $position, array $expectedItems)
+    {
+        $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/foreach.php');
+        $this->loader->open($completionUri, file_get_contents($completionUri));
+        $items = $this->textDocument->completion(
+            new TextDocumentIdentifier($completionUri),
+            $position
+        )->wait();
+        $this->assertCompletionsListSubset(new CompletionList($expectedItems, true), $items);
+    }
+
+    public function foreachProvider(): array
+    {
+        return [
+            'foreach value' => [
+                new Position(18, 6),
+                [
+                    new CompletionItem(
+                        '$value',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(18, 6), new Position(18, 6)), 'alue')
+                    ),
+                ]
+            ],
+            'foreach value resolved' => [
+                new Position(19, 12),
+                [
+                    new CompletionItem(
+                        'foo',
+                        CompletionItemKind::PROPERTY,
+                        'mixed'
+                    ),
+                    new CompletionItem(
+                        'test',
+                        CompletionItemKind::METHOD,
+                        '\\Foo\\Bar[]'
+                    ),
+                ]
+            ],
+            'array creation with multiple objects' => [
+                new Position(23, 5),
+                [
+                    new CompletionItem(
+                        '$value',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar|\\stdClass',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(23, 5), new Position(23, 5)), 'value')
+                    ),
+                    new CompletionItem(
+                        '$key',
+                        CompletionItemKind::VARIABLE,
+                        'int',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(23, 5), new Position(23, 5)), 'key')
+                    ),
+                ]
+            ],
+            'array creation with string/int keys and object values' => [
+                new Position(27, 5),
+                [
+                    new CompletionItem(
+                        '$value',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(27, 5), new Position(27, 5)), 'value')
+                    ),
+                    new CompletionItem(
+                        '$key',
+                        CompletionItemKind::VARIABLE,
+                        'string|int',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(27, 5), new Position(27, 5)), 'key')
+                    ),
+                ]
+            ],
+            'array creation with only string keys' => [
+                new Position(31, 5),
+                [
+                    new CompletionItem(
+                        '$value',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(31, 5), new Position(31, 5)), 'value')
+                    ),
+                    new CompletionItem(
+                        '$key',
+                        CompletionItemKind::VARIABLE,
+                        'string',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(31, 5), new Position(31, 5)), 'key')
+                    ),
+                ]
+            ],
+            'foreach with list()' => [
+                new Position(35, 5),
+                [
+                    new CompletionItem(
+                        '$z',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar|\\stdClass',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(35, 5), new Position(35, 5)), 'z')
+                    ),
+                    new CompletionItem(
+                        '$y',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar|\\stdClass',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(35, 5), new Position(35, 5)), 'y')
+                    ),
+                ]
+            ],
+            'foreach function call' => [
+                new Position(39, 5),
+                [
+                    new CompletionItem(
+                        '$value',
+                        CompletionItemKind::VARIABLE,
+                        '\\Foo\\Bar',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(39, 5), new Position(39, 5)), 'value')
+                    ),
+                ]
+            ],
+        ];
+    }
+
     public function testMethodReturnType()
     {
         $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/method_return_type.php');

--- a/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
+++ b/tests/Validation/cases/arrayValueShouldBeBoolean.php.expected.json
@@ -36,7 +36,7 @@
                 },
                 "containerName": "A"
             },
-            "type__tostring": "string[]",
+            "type__tostring": "bool[]",
             "type": {},
             "declarationLine": "protected $foo;",
             "documentation": null,

--- a/tests/Validation/cases/magicConsts.php.expected.json
+++ b/tests/Validation/cases/magicConsts.php.expected.json
@@ -40,7 +40,7 @@
                 },
                 "containerName": "A"
             },
-            "type__tostring": "\\__CLASS__[]",
+            "type__tostring": "bool[]",
             "type": {},
             "declarationLine": "private static $deprecationsTriggered;",
             "documentation": null,


### PR DESCRIPTION
This adds some basic support for completing `foreach` keys/values. For a complete list of what works have a look at the test, but I believe most "normal" cases work.

Limitations:

* Using `list()` for values is unsupported. This isn't straightforward, and as far as I can tell we don't support a straight up `list()` (outside a foreach) for completion
* No support for iterating public object properties
* No support for `\Traversable` objects

I think implementing these limitations is probably more significant work than what's here. I think the cases that work are probably the most used/popular, so even given these limitations I think this would be worth having. We can work on the missing bits in the future.

Closes #200 