### PR TITLE
Fix crash on unknown foreach type

### DIFF
--- a/fixtures/completion/foreach.php
+++ b/fixtures/completion/foreach.php
@@ -35,3 +35,6 @@ foreach ($array3 as $key => $value) {
 foreach ($bar->test() as $value) {
     $
 }
+
+foreach ($unknownArray as $unknown) {
+    $unkno

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -1122,6 +1122,7 @@ class DefinitionResolver
             if ($collectionType instanceof Types\Array_) {
                 return $collectionType->getValueType();
             }
+            return new Types\Mixed_();
         }
 
         // PROPERTIES, CONSTS, CLASS CONSTS, ASSIGNMENT EXPRESSIONS

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -691,6 +691,21 @@ class CompletionTest extends TestCase
                     ),
                 ]
             ],
+            'foreach unknown type' => [
+                new Position(39, 10),
+                [
+                    new CompletionItem(
+                        '$unknown',
+                        CompletionItemKind::VARIABLE,
+                        'mixed',
+                        null,
+                        null,
+                        null,
+                        null,
+                        new TextEdit(new Range(new Position(39, 10), new Position(39, 10)), 'wn')
+                    ),
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes a crash when a node in a foreach expression cannot be resolved to a type.

Fixes #561 