### PR TITLE
Fix crash when foreach key isn't a variable

### DIFF
--- a/fixtures/completion/foreach.php
+++ b/fixtures/completion/foreach.php
@@ -36,5 +36,5 @@ foreach ($bar->test() as $value) {
     $
 }
 
-foreach ($unknownArray as $unknown) {
+foreach ($unknownArray as $member->access => $unknown) {
     $unkno

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -571,7 +571,9 @@ class DefinitionResolver
 
             // If we get to a ForeachStatement, check the keys and values
             if ($n instanceof Node\Statement\ForeachStatement) {
-                if ($n->foreachKey && $n->foreachKey->expression->getName() === $name) {
+                if ($n->foreachKey instanceof Node\Expression\Variable
+                    && $n->foreachKey->expression->getName() === $name
+                ) {
                     return $n->foreachKey;
                 }
                 if ($n->foreachValue


### PR DESCRIPTION
This fixes a crash when a foreach key is not a straight up variable (which I hadn't realised was possible), e.g. this is valid:

```php
<?php

$arr = [1,2,3];
$a = new stdClass();
foreach ($arr as $a->key => $value) {
    echo "{$a->key}: $value\n";
}
```

Fixes #563