### PR TITLE
Fix infinite loop in foreach resolving

### DIFF
--- a/fixtures/completion/foreach.php
+++ b/fixtures/completion/foreach.php
@@ -38,3 +38,10 @@ foreach ($bar->test() as $value) {
 
 foreach ($unknownArray as $unknown) {
     $unkno
+}
+
+foreach ($loop as $loop) {
+}
+
+foreach ($loop->getArray() as $loop) {
+}


### PR DESCRIPTION
There is a bug that occurs when we come across code like:

```php
foreach ($a->getArray() as $a) {
```

Where in `resolveVariableToNode`, when we try to find where `$a` was defined, we have to traverse the AST up. So if we are within the loop and we come across `$a`, we traverse up and find the `foreach` statement, and find it is defined as the forEachValue. Then we want to find where that was defined, and we get to the forEachCollection (`$a->getArray()`) and we again have to traverse up the tree to find $a. We come come across the `foreach` statement again - and there isn't a way to identify that we got there from within the `foreach` statement, so we do the same as if we came from within the foreach loop and check the key/value, find it in the value... and we're stuck in a loop.

The only way I've found to fix this is identify if we get to the `foreach` statement from the the `forEachCollectionName`, in which case we do not want to check the key/value.

Closes #566 
Closes felixfbecker/vscode-php-intellisense#192