### PR TITLE
Fix benchmark on case sensitive filesystems

### DIFF
--- a/Performance.php
+++ b/Performance.php
@@ -14,7 +14,7 @@ use RecursiveIteratorIterator;
 
 $totalSize = 0;
 
-$frameworks = ["drupal", "wordpress", "php-language-server", "tolerant-php-parser", "math-php", "symfony", "CodeIgniter", "cakephp"];
+$frameworks = ["drupal", "wordpress", "php-language-server", "tolerant-php-parser", "math-php", "symfony", "codeigniter", "cakephp"];
 
 foreach($frameworks as $framework) {
     $iterator = new RecursiveDirectoryIterator(__DIR__ . "/validation/frameworks/$framework");


### PR DESCRIPTION
On case insensitive file systems, such as the defaults for Mac OS/Windows, this works, but it doesn't work for ext4, etc.

The folder being checked out is `validation/frameworks/codeigniter`, this searched for `validation/frameworks/CodeIgniter`

```
[submodule "validation/frameworks/codeigniter"]
    path = validation/frameworks/codeigniter
    url = https://github.com/bcit-ci/codeigniter
```