### PR TITLE
fix proposing php start tag when completion context is not given by the ls client

### DIFF
--- a/src/CompletionProvider.php
+++ b/src/CompletionProvider.php
@@ -162,10 +162,12 @@ class CompletionProvider
             || (
                 $node instanceof Node\Statement\InlineHtml
                 && (
-                    $context === null
+                    $context !== null
                     // Make sure to not suggest on the > trigger character in HTML
-                    || $context->triggerKind === CompletionTriggerKind::INVOKED
-                    || $context->triggerCharacter === '<'
+                    && (
+                        $context->triggerKind === CompletionTriggerKind::INVOKED
+                        || $context->triggerCharacter === '<'
+                    )
                 )
             )
             || $pos == new Position(0, 0)

--- a/tests/Server/TextDocument/CompletionTest.php
+++ b/tests/Server/TextDocument/CompletionTest.php
@@ -444,7 +444,7 @@ class CompletionTest extends TestCase
         ], true), $items);
     }
 
-    public function testHtmlWithPrefix()
+    public function testHtmlWontBeProposedWithoutCompletionContext()
     {
         $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/html_with_prefix.php');
         $this->loader->open($completionUri, file_get_contents($completionUri));
@@ -452,7 +452,21 @@ class CompletionTest extends TestCase
             new TextDocumentIdentifier($completionUri),
             new Position(0, 1)
         )->wait();
-        $this->assertCompletionsListSubset(new CompletionList([
+
+        $this->assertEquals(new CompletionList([], true), $items);
+    }
+
+    public function testHtmlWontBeProposedWithPrefixWithCompletionContext()
+    {
+        $completionUri = pathToUri(__DIR__ . '/../../../fixtures/completion/html_with_prefix.php');
+        $this->loader->open($completionUri, file_get_contents($completionUri));
+        $items = $this->textDocument->completion(
+            new TextDocumentIdentifier($completionUri),
+            new Position(0, 1),
+            new CompletionContext(CompletionTriggerKind::TRIGGER_CHARACTER, '<')
+        )->wait();
+
+        $this->assertEquals(new CompletionList([
             new CompletionItem(
                 '<?php',
                 CompletionItemKind::KEYWORD,


### PR DESCRIPTION
*cough* vscode *cough*

fixes https://github.com/felixfbecker/php-language-server/issues/372