### PR TITLE
Fix: Allow integer FQNs in references in PhpDocument

### DIFF
--- a/Performance.php
+++ b/Performance.php
@@ -51,11 +51,7 @@ foreach($frameworks as $framework) {
         $definitionResolver = new DefinitionResolver($index);
         $parser = new PhpParser\Parser();
 
-        try {
-            $document = new PhpDocument($testCaseFile, $fileContents, $index, $parser, $docBlockFactory, $definitionResolver);
-        } catch (\Throwable $e) {
-            continue;
-        }
+        $document = new PhpDocument($testCaseFile, $fileContents, $index, $parser, $docBlockFactory, $definitionResolver);
     }
 
     echo "------------------------------\n";

--- a/src/PhpDocument.php
+++ b/src/PhpDocument.php
@@ -160,7 +160,9 @@ class PhpDocument
 
         // Register this document on the project for references
         foreach ($this->referenceNodes as $fqn => $nodes) {
-            $this->index->addReferenceUri($fqn, $this->uri);
+            // Cast the key to string. If (string)'2' is set as an array index, it will read out as (int)2. We must
+            // deal with incorrect code, so this is a valid scenario.
+            $this->index->addReferenceUri((string)$fqn, $this->uri);
         }
 
         $this->sourceFileNode = $treeAnalyzer->getSourceFileNode();


### PR DESCRIPTION
Sometimes with incorrect code, a number is parsed as an FQN. When it is added to an array as its key, it will be converted to an integer. This causes a type error when it is added to references.

This fixes an exception that gets thrown when running Performance.php. I also removed the `try { ... } catch` block from Performance.php, which would make testing of performance changes easier as increased exception rate would not be interpreted as increased performance.