### PR TITLE
Remove unused 'use' statements

### DIFF
--- a/src/Cache/FileSystemCache.php
+++ b/src/Cache/FileSystemCache.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace LanguageServer\Cache;
 
-use LanguageServer\LanguageClient;
 use Sabre\Event\Promise;
 
 /**

--- a/src/Client/TextDocument.php
+++ b/src/Client/TextDocument.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace LanguageServer\Client;
 
 use LanguageServer\ClientHandler;
-use LanguageServer\Protocol\{Message, TextDocumentItem, TextDocumentIdentifier};
+use LanguageServer\Protocol\{TextDocumentItem, TextDocumentIdentifier};
 use Sabre\Event\Promise;
 use JsonMapper;
 

--- a/src/Client/Window.php
+++ b/src/Client/Window.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace LanguageServer\Client;
 
 use LanguageServer\ClientHandler;
-use LanguageServer\Protocol\Message;
 use Sabre\Event\Promise;
 
 /**

--- a/src/Client/XCache.php
+++ b/src/Client/XCache.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace LanguageServer\Client;
 
 use LanguageServer\ClientHandler;
-use LanguageServer\Protocol\Message;
 use Sabre\Event\Promise;
 
 /**

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -6,7 +6,6 @@ namespace LanguageServer;
 use LanguageServer\Index\ReadableIndex;
 use phpDocumentor\Reflection\{Types, Type, Fqsen, TypeResolver};
 use LanguageServer\Protocol\SymbolInformation;
-use Exception;
 use Generator;
 
 /**
@@ -69,7 +68,7 @@ class Definition
     public $canBeInstantiated;
 
     /**
-     * @var Protocol\SymbolInformation
+     * @var SymbolInformation
      */
     public $symbolInformation;
 

--- a/src/FqnUtilities.php
+++ b/src/FqnUtilities.php
@@ -3,7 +3,6 @@
 namespace LanguageServer\FqnUtilities;
 
 use phpDocumentor\Reflection\{Type, Types};
-use Microsoft\PhpParser;
 
 /**
  * Returns all possible FQNs in a type

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -6,10 +6,8 @@ namespace LanguageServer;
 use LanguageServer\Cache\Cache;
 use LanguageServer\FilesFinder\FilesFinder;
 use LanguageServer\Index\{DependenciesIndex, Index};
-use LanguageServer\Protocol\Message;
 use LanguageServer\Protocol\MessageType;
 use Webmozart\PathUtil\Path;
-use Composer\Semver\VersionParser;
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
 

--- a/src/Protocol/SymbolInformation.php
+++ b/src/Protocol/SymbolInformation.php
@@ -4,7 +4,6 @@ namespace LanguageServer\Protocol;
 
 use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
-use Exception;
 
 /**
  * Represents information about programming constructs like variables, classes,

--- a/src/ProtocolStreamWriter.php
+++ b/src/ProtocolStreamWriter.php
@@ -8,7 +8,6 @@ use Sabre\Event\{
     Loop,
     Promise
 };
-use RuntimeException;
 
 class ProtocolStreamWriter implements ProtocolWriter
 {

--- a/src/Server/TextDocument.php
+++ b/src/Server/TextDocument.php
@@ -23,7 +23,6 @@ use LanguageServer\Protocol\{
     VersionedTextDocumentIdentifier,
     CompletionContext
 };
-use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
 use Sabre\Event\Promise;
 use Sabre\Uri;

--- a/src/Server/Workspace.php
+++ b/src/Server/Workspace.php
@@ -3,18 +3,16 @@ declare(strict_types = 1);
 
 namespace LanguageServer\Server;
 
-use LanguageServer\{LanguageClient, Project, PhpDocumentLoader};
+use LanguageServer\{LanguageClient, PhpDocumentLoader};
 use LanguageServer\Index\{ProjectIndex, DependenciesIndex, Index};
 use LanguageServer\Protocol\{
     FileChangeType,
     FileEvent,
     SymbolInformation,
     SymbolDescriptor,
-    PackageDescriptor,
     ReferenceInformation,
     DependencyReference,
-    Location,
-    MessageType
+    Location
 };
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;

--- a/src/SignatureHelpProvider.php
+++ b/src/SignatureHelpProvider.php
@@ -7,10 +7,8 @@ use LanguageServer\Index\ReadableIndex;
 use LanguageServer\Protocol\{
     Position,
     SignatureHelp,
-    SignatureInformation,
     ParameterInformation
 };
-use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;

--- a/src/TreeAnalyzer.php
+++ b/src/TreeAnalyzer.php
@@ -3,10 +3,8 @@ declare(strict_types = 1);
 
 namespace LanguageServer;
 
-use LanguageServer\Protocol\{Diagnostic, DiagnosticSeverity, Range, Position, TextEdit};
-use LanguageServer\Index\Index;
+use LanguageServer\Protocol\{Diagnostic, DiagnosticSeverity, Range, Position};
 use phpDocumentor\Reflection\DocBlockFactory;
-use Sabre\Uri;
 use Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;


### PR DESCRIPTION
detected via static analysis and manually checked.

Unit tests continue to pass.