### PR TITLE
chore: exclude appveyor.yml in production

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /.gitmodules export-ignore
 /.npmrc export-ignore
 /.travis.yml export-ignore
+/appveyor.yml export-ignore
 /codecov.yml export-ignore
 /dependencies.yml export-ignore
 /Dockerfile export-ignore


### PR DESCRIPTION
Added the `appveyor.yml` file to `.gitattributes`.