### PR TITLE
make dependencies not released be able to cache

### DIFF
--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -151,8 +151,13 @@ class Indexer
                     // Check if package name matches and version is absolute
                     // Dynamic constraints are not cached, because they can change every time
                     $packageVersion = ltrim($package->version, 'v');
-                    if ($package->name === $packageName && strpos($packageVersion, 'dev') === false) {
+                    if ($package->name === $packageName) {
                         $packageKey = $packageName . ':' . $packageVersion;
+                        if (strpos($packageVersion, 'dev') !== false) {
+                            $packageKey = $packageName . ':' . (isset($package->source) && isset($package->source->reference) ? 
+                                $package->source->reference : (isset($package->dist) && isset($package->dist->reference) ? 
+                                    $package->source->reference : $packageVersion));
+                        }
                         $cacheKey = self::CACHE_VERSION . ':' . $packageKey;
                         // Check cache
                         $index = yield $this->cache->get($cacheKey);

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -152,12 +152,16 @@ class Indexer
                     // Dynamic constraints are not cached, because they can change every time
                     $packageVersion = ltrim($package->version, 'v');
                     if ($package->name === $packageName) {
-                        $packageKey = $packageName . ':' . $packageVersion;
                         if (strpos($packageVersion, 'dev') !== false) {
-                            $packageKey = $packageName . ':' . (isset($package->source) && isset($package->source->reference) ? 
-                                $package->source->reference : (isset($package->dist) && isset($package->dist->reference) ? 
-                                    $package->source->reference : $packageVersion));
+                            if (isset($package->source) && isset($package->source->reference)) {
+                                $packageVersion = $package->source->reference;
+                            } else {
+                                if (isset($package->dist) && isset($package->dist->reference)) {
+                                    $packageVersion = $package->source->reference;
+                                }
+                            }
                         }
+                        $packageKey = $packageName . ':' . $packageVersion;
                         $cacheKey = self::CACHE_VERSION . ':' . $packageKey;
                         // Check cache
                         $index = yield $this->cache->get($cacheKey);


### PR DESCRIPTION
This pull request is coming to enhance issue #617 

Testing snapshots:

![image](https://user-images.githubusercontent.com/6964962/37557966-72184a98-2a47-11e8-8585-f8fd05230612.png)
![image](https://user-images.githubusercontent.com/6964962/37557979-92d18056-2a47-11e8-935c-850e8543be7b.png)

picture 1 is a laravel project,
picture 2 is felixfbecker.php-intellisense it self, and does not contain dev dependency.
