### PR TITLE
Include local and global installation instructions in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,9 @@ All classes are considered internal and are not subject to semver.
 ## Installation
 
 The recommended installation method is through [Composer](https://getcomposer.org/).
-Simply run
 
-    composer require felixfbecker/language-server
 
-and you will get the latest stable release and all dependencies.  
-Running `composer update` will update the server to the latest non-breaking version.
-
-After installing the language server and its dependencies,
-you must parse the stubs for standard PHP symbols and save the index for fast initialization.
-
-     composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
-# Local installation
+### Local Installation
 Create a directory for php-language-server. Create a composer.json file in it, with the following contents:
 
 ```
@@ -176,7 +167,15 @@ composer global require felixfbecker/language-server
 composer global run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
 
-Slightly altered from a guide found [here ](https://github.com/emacs-lsp/lsp-php). 
+
+and you will get the latest stable release and all dependencies.  
+Running `composer update` will update the server to the latest non-breaking version.
+
+After installing the language server and its dependencies,
+you must parse the stubs for standard PHP symbols and save the index for fast initialization.
+
+     composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+
 ## Running
 
 Start the language server with

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ All classes are considered internal and are not subject to semver.
 
 The recommended installation method is through [Composer](https://getcomposer.org/).
 
+```composer require felixfbecker/language-server```
 
 ### Local Installation
 Create a directory for php-language-server. Create a composer.json file in it, with the following contents:

--- a/README.md
+++ b/README.md
@@ -140,14 +140,21 @@ Create a directory for php-language-server. Create a composer.json file in it, w
 ```
 {
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require": {
+        "felixfbecker/language-server": "v5.4.0"
+    },
+    "scripts": {
+        "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs",
+        "post-update-cmd": "@parse-stubs",
+        "post-install-cmd": "@parse-stubs"
+    }
 }
 ```
 Then, in the directory, run the following commands:
 
 ```
 composer require felixfbecker/language-server
-composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
 
 ### Global installation
@@ -156,14 +163,22 @@ Before installing php-language-server, make sure your ~/.config/composer/compose
 ```
 {
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "require": {
+        "felixfbecker/language-server": "v5.4.0"
+    },
+    "scripts": {
+        "parse-stubs": "LanguageServer\\ComposerScripts::parseStubs",
+        "post-update-cmd": "@parse-stubs",
+        "post-install-cmd": "@parse-stubs"
+    }
 }
+
 ```
 After editing your composer.json, you can install felixfbecker/php-language-server.
 
 ```
 composer global require felixfbecker/language-server
-composer global run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -144,7 +144,39 @@ After installing the language server and its dependencies,
 you must parse the stubs for standard PHP symbols and save the index for fast initialization.
 
      composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+# Local installation
+Create a directory for php-language-server. Create a composer.json file in it, with the following contents:
 
+```
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+Then, in the directory, run the following commands:
+
+```
+composer require felixfbecker/language-server
+composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+```
+
+# Global installation
+Before installing php-language-server, make sure your ~/.config/composer/composer.json includes the lines below. The settings apply to all globally installed Composer packages, so proceed with caution. If you do not want to edit your global Composer configuration, see the section for local installation above.
+
+```
+{
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}
+```
+After editing your composer.json, you can install felixfbecker/php-language-server. The following instructions have been adapted from the installation section of php-language-server
+
+```
+composer global require felixfbecker/language-server
+composer global run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
+```
+
+Slightly altered from a guide found [here ](https://github.com/emacs-lsp/lsp-php). 
 ## Running
 
 Start the language server with

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Before installing php-language-server, make sure your ~/.config/composer/compose
     "prefer-stable": true
 }
 ```
-After editing your composer.json, you can install felixfbecker/php-language-server. The following instructions have been adapted from the installation section of php-language-server
+After editing your composer.json, you can install felixfbecker/php-language-server.
 
 ```
 composer global require felixfbecker/language-server

--- a/README.md
+++ b/README.md
@@ -132,9 +132,7 @@ All classes are considered internal and are not subject to semver.
 
 ## Installation
 
-The recommended installation method is through [Composer](https://getcomposer.org/).
-
-```composer require felixfbecker/language-server```
+The recommended installation method is through [Composer](https://getcomposer.org/).  Follow the following installation instructions for local or global installation after installing composer on your system.
 
 ### Local Installation
 Create a directory for php-language-server. Create a composer.json file in it, with the following contents:
@@ -152,7 +150,7 @@ composer require felixfbecker/language-server
 composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
 
-# Global installation
+### Global installation
 Before installing php-language-server, make sure your ~/.config/composer/composer.json includes the lines below. The settings apply to all globally installed Composer packages, so proceed with caution. If you do not want to edit your global Composer configuration, see the section for local installation above.
 
 ```
@@ -167,15 +165,6 @@ After editing your composer.json, you can install felixfbecker/php-language-serv
 composer global require felixfbecker/language-server
 composer global run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 ```
-
-
-and you will get the latest stable release and all dependencies.  
-Running `composer update` will update the server to the latest non-breaking version.
-
-After installing the language server and its dependencies,
-you must parse the stubs for standard PHP symbols and save the index for fast initialization.
-
-     composer run-script --working-dir=vendor/felixfbecker/language-server parse-stubs
 
 ## Running
 


### PR DESCRIPTION
This pull request alters the installation section of the readme to include the installation instructions found at [emacs-lsp/lsp-php](https://github.com/emacs-lsp/lsp-php )

I found that guide helpful. Hopefully it helps others. 

