### PR TITLE
Ensure all dependencies in a multi-root project are cached

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -215,10 +215,18 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     sortUrisLevelOrder($composerLockFiles);
 
                     if (!empty($composerLockFiles)) {
-                        $this->composerLock = json_decode(yield $this->contentRetriever->retrieve($composerLockFiles[0]));
+                        $packages = [];
+                        $packagesDev = [];
+                        foreach($composerLockFiles as $composerLockFile) {
+                            $composerLock = json_decode(yield $this->contentRetriever->retrieve($composerLockFile));
+                            $packages = array_merge($packages, $composerLock->packages);
+                            $packagesDev = array_merge($packagesDev, $composerLock->{'packages-dev'});
+                        }
+                        $this->composerLock = $composerLock;
+                        $this->composerLock->packages = $packages;
+                        $this->composerLock->{'packages-dev'} = $packagesDev;
                     }
                 }
-
                 $cache = $capabilities->xcacheProvider ? new ClientCache($this->client) : new FileSystemCache;
 
                 // Index in background


### PR DESCRIPTION
I've had issues with a multi-root project where CPU runs through the roof every time https://github.com/felixfbecker/vscode-php-intellisense is opened.

The reason for this was LanguageServer.php was arbitrarily choosing the first composer.lock that it came across within rootPath, then indexing and caching dependencies from it alone.  Consequently, whenever VSCode restarts, php-language-server re-indexes all of the vendor packages in sub-folders that weren't associated with the selected composer.json/lock file.

My quick patch here simply iterates over all composer.lock files within the multi-root project, indexes then caches to disk every single dependency it uncovers. The result of this being that subsequent startup times are much faster and CPU no longer tanks.

This is my simple solution which I believe partially solves what https://github.com/felixfbecker/php-language-server/pull/509 is attempting to address. Possibly related to https://github.com/felixfbecker/php-language-server/issues/465
