### PR TITLE
Fix infinite loop when indexing self referencing classes

### DIFF
--- a/fixtures/self_referencing_class.php
+++ b/fixtures/self_referencing_class.php
@@ -1,0 +1,4 @@
+<?php
+class C extends C {}
+$c = new C;
+$c->undef_prop = 1;

--- a/src/DefinitionResolver.php
+++ b/src/DefinitionResolver.php
@@ -452,7 +452,9 @@ class DefinitionResolver
             // Repeat for parent class
             if ($implementorDef->extends) {
                 foreach ($implementorDef->extends as $extends) {
-                    $implementorFqns[] = $extends;
+                    if ($extends !== $implementorFqn) {
+                        $implementorFqns[] = $extends;
+                    }
                 }
             }
         }


### PR DESCRIPTION
As the indexer attempts to parse the parent class, it adds itself to the array being iterated.

A simple check that the FQN isn't identical resolves the issue.