### PR TITLE
Fix impossible `parse_url` equality

### DIFF
--- a/src/utils.php
+++ b/src/utils.php
@@ -38,7 +38,7 @@ function pathToUri(string $filepath): string
 function uriToPath(string $uri)
 {
     $fragments = parse_url($uri);
-    if ($fragments === null || !isset($fragments['scheme']) || $fragments['scheme'] !== 'file') {
+    if ($fragments === false || !isset($fragments['scheme']) || $fragments['scheme'] !== 'file') {
         throw new InvalidArgumentException("Not a valid file URI: $uri");
     }
     $filepath = urldecode($fragments['path']);


### PR DESCRIPTION
`parse_url` returns `false` for malformed urls, not `null`