### PR TITLE
Run 'composer install' in a docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,21 @@
 
+FROM composer AS builder
+
+COPY ./ /app
+RUN composer install
+
 # Running this container will start a language server that listens for TCP connections on port 2088
 # Every connection will be run in a forked child process
 
 # Please note that before building the image, you have to install dependencies with `composer install`
 
 FROM php:7-cli
-MAINTAINER Felix Becker <felix.b@outlook.com>
 
 RUN docker-php-ext-configure pcntl --enable-pcntl
 RUN docker-php-ext-install pcntl
 COPY ./php.ini /usr/local/etc/php/conf.d/
 
-COPY ./ /srv/phpls
+COPY --from=builder /app /srv/phpls
 
 WORKDIR /srv/phpls
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,13 @@
+# Running this container will start a language server that listens for TCP connections on port 2088
+# Every connection will be run in a forked child process
 
 FROM composer AS builder
 
 COPY ./ /app
 RUN composer install
 
-# Running this container will start a language server that listens for TCP connections on port 2088
-# Every connection will be run in a forked child process
-
 FROM php:7-cli
-MAINTAINER Felix Becker <felix.b@outlook.com>
+LABEL maintainer="Felix Becker <felix.b@outlook.com>"
 
 RUN docker-php-ext-configure pcntl --enable-pcntl
 RUN docker-php-ext-install pcntl

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN composer install
 # Please note that before building the image, you have to install dependencies with `composer install`
 
 FROM php:7-cli
+MAINTAINER Felix Becker <felix.b@outlook.com>
 
 RUN docker-php-ext-configure pcntl --enable-pcntl
 RUN docker-php-ext-install pcntl

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN composer install
 # Running this container will start a language server that listens for TCP connections on port 2088
 # Every connection will be run in a forked child process
 
-# Please note that before building the image, you have to install dependencies with `composer install`
-
 FROM php:7-cli
 MAINTAINER Felix Becker <felix.b@outlook.com>
 


### PR DESCRIPTION
I wondered on the comment in the Dockerfile, which says to install the composer dependencies before building the image. 

Maybe it is an option for you to use a multi-stage Dockerfile, like i proposed in my PR :) I would appreciate to hear your thoughts about that.