### PR TITLE
content-limit become configurable

### DIFF
--- a/bin/php-language-server.php
+++ b/bin/php-language-server.php
@@ -1,10 +1,10 @@
 <?php
 
-use LanguageServer\{LanguageServer, ProtocolStreamReader, ProtocolStreamWriter, StderrLogger};
+use LanguageServer\{LanguageServer, ProtocolStreamReader, ProtocolStreamWriter, StderrLogger, ContentTooLargeException};
 use Sabre\Event\Loop;
 use Composer\XdebugHandler\XdebugHandler;
 
-$options = getopt('', ['tcp::', 'tcp-server::', 'memory-limit::']);
+$options = getopt('', ['tcp::', 'tcp-server::', 'memory-limit::', "content-limit::"]);
 
 ini_set('memory_limit', $options['memory-limit'] ?? '4G');
 
@@ -38,6 +38,10 @@ $xdebugHandler = new XdebugHandler('PHPLS');
 $xdebugHandler->setLogger($logger);
 $xdebugHandler->check();
 unset($xdebugHandler);
+
+if (is_integer($options['content-limit'] ?? null)) {
+    ContentTooLargeException::$limit = (int)$options['content-limit'];
+}
 
 if (!empty($options['tcp'])) {
     // Connect to a TCP server

--- a/src/ContentRetriever/FileSystemContentRetriever.php
+++ b/src/ContentRetriever/FileSystemContentRetriever.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace LanguageServer\ContentRetriever;
 
+use LanguageServer\ContentTooLargeException;
 use Sabre\Event\Promise;
 use function LanguageServer\uriToPath;
 
@@ -19,6 +20,13 @@ class FileSystemContentRetriever implements ContentRetriever
      */
     public function retrieve(string $uri): Promise
     {
-        return Promise\resolve(file_get_contents(uriToPath($uri)));
+        $limit = 150000;
+
+        $path = uriToPath($uri);
+        $size = filesize($path);
+        if ($size > $limit) {
+            return Promise\reject(new ContentTooLargeException($uri, $size, $limit));
+        }
+        return Promise\resolve(file_get_contents($path));
     }
 }

--- a/src/ContentRetriever/FileSystemContentRetriever.php
+++ b/src/ContentRetriever/FileSystemContentRetriever.php
@@ -20,12 +20,10 @@ class FileSystemContentRetriever implements ContentRetriever
      */
     public function retrieve(string $uri): Promise
     {
-        $limit = 150000;
-
         $path = uriToPath($uri);
         $size = filesize($path);
-        if ($size > $limit) {
-            return Promise\reject(new ContentTooLargeException($uri, $size, $limit));
+        if ($size > ContentTooLargeException::$limit) {
+            return Promise\reject(new ContentTooLargeException($uri, $size));
         }
         return Promise\resolve(file_get_contents($path));
     }

--- a/src/ContentTooLargeException.php
+++ b/src/ContentTooLargeException.php
@@ -9,6 +9,13 @@ namespace LanguageServer;
 class ContentTooLargeException extends \Exception
 {
     /**
+     * The limit of content
+     *
+     * @var int
+     */
+    public static $limit = 1000000;
+
+    /**
      * The URI of the file that exceeded the limit
      *
      * @var string
@@ -23,23 +30,15 @@ class ContentTooLargeException extends \Exception
     public $size;
 
     /**
-     * The limit that was exceeded in bytes
-     *
-     * @var int
-     */
-    public $limit;
-
-    /**
      * @param string     $uri      The URI of the file that exceeded the limit
      * @param int        $size     The size of the file in bytes
-     * @param int        $limit    The limit that was exceeded in bytes
      * @param \Throwable $previous The previous exception used for the exception chaining.
      */
-    public function __construct(string $uri, int $size, int $limit, \Throwable $previous = null)
+    public function __construct(string $uri, int $size, \Throwable $previous = null)
     {
         $this->uri = $uri;
         $this->size = $size;
-        $this->limit = $limit;
+        $limit = self::$limit;
         parent::__construct("$uri exceeds size limit of $limit bytes ($size)", 0, $previous);
     }
 }

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -218,9 +218,10 @@ class Indexer
                         $this->client->textDocument->publishDiagnostics($uri, $document->getDiagnostics());
                     }
                 } catch (ContentTooLargeException $e) {
+                    $limit = ContentTooLargeException::$limit;
                     $this->client->window->logMessage(
                         MessageType::INFO,
-                        "Ignoring file {$uri} because it exceeds size limit of {$e->limit} bytes ({$e->size})"
+                        "Ignoring file {$uri} because it exceeds size limit of {$limit} bytes ({$e->size})"
                     );
                 } catch (\Exception $e) {
                     $this->client->window->logMessage(MessageType::ERROR, "Error parsing $uri: " . (string)$e);

--- a/src/PhpDocumentLoader.php
+++ b/src/PhpDocumentLoader.php
@@ -105,13 +105,7 @@ class PhpDocumentLoader
     public function load(string $uri): Promise
     {
         return coroutine(function () use ($uri) {
-
-            $limit = 150000;
             $content = yield $this->contentRetriever->retrieve($uri);
-            $size = strlen($content);
-            if ($size > $limit) {
-                throw new ContentTooLargeException($uri, $size, $limit);
-            }
 
             if (isset($this->documents[$uri])) {
                 $document = $this->documents[$uri];


### PR DESCRIPTION
1. add `content-limit` option.
2. do not retrieve content if it's too large 