### PR TITLE
Prevent "undefined index" notice if $parts array is empty in Index\Index#removeIndexedDefinition

### DIFF
--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -423,6 +423,10 @@ class Index implements ReadableIndex, \Serializable
      */
     private function removeIndexedDefinition(int $level, array $parts, array &$storage, array &$rootStorage)
     {
+        if (empty($parts)) {
+            return;
+        }
+        
         $part = $parts[$level];
 
         if ($level + 1 === count($parts)) {


### PR DESCRIPTION
If `$level` reaches 0 with only one more element in the `$parts` array, the next call to `array_slice($parts, 0, $level)` will return an empty array. This will trigger a "undefined index" notice in the next recursion on `$part = $parts[$level]`. This notice gets promoted to an ErrorException in the error-handler (if the local php.ini is configured to report notices) which will cancel further processing.

Fixes #695