### PR TITLE
Add support for `workspace/didChangeConfiguration` and the excludePatterns option

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer;
+
+class Configuration
+{
+    /**
+     * @var string[]
+     */
+    public $excludePatterns;
+
+    public function __construct(array $excludePatterns = [])
+    {
+        $this->excludePatterns = $excludePatterns;
+    }
+}

--- a/src/FilesFinder/ClientFilesFinder.php
+++ b/src/FilesFinder/ClientFilesFinder.php
@@ -33,13 +33,13 @@ class ClientFilesFinder implements FilesFinder
      * @param string $glob
      * @return Promise <string[]> The URIs
      */
-    public function find(string $glob): Promise
+    public function find(string $glob, array $excludePatterns = []): Promise
     {
-        return $this->client->workspace->xfiles()->then(function (array $textDocuments) use ($glob) {
+        return $this->client->workspace->xfiles()->then(function (array $textDocuments) use ($glob, $excludePatterns) {
             $uris = [];
             foreach ($textDocuments as $textDocument) {
                 $path = Uri\parse($textDocument->uri)['path'];
-                if (Glob::match($path, $glob)) {
+                if (matchGlobs($path, [ $glob ]) && !matchGlobs($path, $excludePatterns)) {
                     $uris[] = $textDocument->uri;
                 }
             }

--- a/src/FilesFinder/FileSystemFilesFinder.php
+++ b/src/FilesFinder/FileSystemFilesFinder.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace LanguageServer\FilesFinder;
 
 use Webmozart\Glob\Iterator\GlobIterator;
-use Webmozart\Glob\Glob;
 use Sabre\Event\Promise;
 use function Sabre\Event\coroutine;
 use function LanguageServer\{pathToUri, timeout};

--- a/src/FilesFinder/FilesFinder.php
+++ b/src/FilesFinder/FilesFinder.php
@@ -17,5 +17,22 @@ interface FilesFinder
      * @param string $glob
      * @return Promise <string[]>
      */
-    public function find(string $glob): Promise;
+    public function find(string $glob, array $excludePatterns): Promise;
+}
+
+/**
+ * Check if a path matches any of the globs
+ * @param string $path
+ * @param string[] $globs An array of globs
+ * @return bool
+ */
+function matchGlobs(string $path, array $globs): bool
+{
+    foreach ($globs as $glob) {
+        if (Glob::match($path, $glob)) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/FilesFinder/FilesFinder.php
+++ b/src/FilesFinder/FilesFinder.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace LanguageServer\FilesFinder;
 
 use Sabre\Event\Promise;
+use Webmozart\Glob\Glob;
 
 /**
  * Interface for finding files in the workspace

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -6,6 +6,7 @@ namespace LanguageServer;
 use LanguageServer\Cache\Cache;
 use LanguageServer\FilesFinder\FilesFinder;
 use LanguageServer\Index\{DependenciesIndex, Index};
+use LanguageServer\Configuration;
 use LanguageServerProtocol\MessageType;
 use Webmozart\PathUtil\Path;
 use Sabre\Event\Promise;
@@ -64,6 +65,11 @@ class Indexer
     private $composerJson;
 
     /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * @param FilesFinder       $filesFinder
      * @param string            $rootPath
      * @param LanguageClient    $client
@@ -81,6 +87,7 @@ class Indexer
         DependenciesIndex $dependenciesIndex,
         Index $sourceIndex,
         PhpDocumentLoader $documentLoader,
+        Configuration $configuration,
         \stdClass $composerLock = null,
         \stdClass $composerJson = null
     ) {
@@ -93,6 +100,7 @@ class Indexer
         $this->documentLoader = $documentLoader;
         $this->composerLock = $composerLock;
         $this->composerJson = $composerJson;
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -113,7 +113,7 @@ class Indexer
         return coroutine(function () {
 
             $pattern = Path::makeAbsolute('**/*.php', $this->rootPath);
-            $uris = yield $this->filesFinder->find($pattern);
+            $uris = yield $this->filesFinder->find($pattern, $this->configuration->excludePatterns);
 
             $count = count($uris);
             $startTime = microtime(true);

--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -199,6 +199,28 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 $this->definitionResolver
             );
 
+            if ($this->textDocument === null) {
+                $this->textDocument = new Server\TextDocument(
+                    $this->documentLoader,
+                    $this->definitionResolver,
+                    $this->client,
+                    $this->globalIndex,
+                    $this->composerJson,
+                    $this->composerLock
+                );
+            }
+            if ($this->workspace === null) {
+                $this->workspace = new Server\Workspace(
+                    $this->client,
+                    $this->projectIndex,
+                    $dependenciesIndex,
+                    $sourceIndex,
+                    $this->composerLock,
+                    $this->documentLoader,
+                    $this->composerJson
+                );
+            }
+
             if ($rootPath !== null) {
                 yield $this->beforeIndex($rootPath);
 
@@ -233,33 +255,11 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                     $dependenciesIndex,
                     $sourceIndex,
                     $this->documentLoader,
+                    $this->workspace->configuration,
                     $this->composerLock,
                     $this->composerJson
                 );
                 $indexer->index()->otherwise('\\LanguageServer\\crash');
-            }
-
-
-            if ($this->textDocument === null) {
-                $this->textDocument = new Server\TextDocument(
-                    $this->documentLoader,
-                    $this->definitionResolver,
-                    $this->client,
-                    $this->globalIndex,
-                    $this->composerJson,
-                    $this->composerLock
-                );
-            }
-            if ($this->workspace === null) {
-                $this->workspace = new Server\Workspace(
-                    $this->client,
-                    $this->projectIndex,
-                    $dependenciesIndex,
-                    $sourceIndex,
-                    $this->composerLock,
-                    $this->documentLoader,
-                    $this->composerJson
-                );
             }
 
             $serverCapabilities = new ServerCapabilities();

--- a/tests/Server/Workspace/DidChangeConfigurationTest.php
+++ b/tests/Server/Workspace/DidChangeConfigurationTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+
+namespace LanguageServer\Tests\Server\Workspace;
+
+use LanguageServer\ContentRetriever\FileSystemContentRetriever;
+use LanguageServer\{DefinitionResolver, LanguageClient, PhpDocumentLoader, Server};
+use LanguageServer\Index\{DependenciesIndex, Index, ProjectIndex};
+use LanguageServer\Message;
+use LanguageServer\Tests\MockProtocolStream;
+use LanguageServer\Tests\Server\ServerTestCase;
+use LanguageServer\Server\Workspace;
+use Sabre\Event\Loop;
+use LanguageServer\Configuration;
+
+class DidChangeConfigurationTest extends ServerTestCase
+{
+    public function testChangeConfiguration()
+    {
+        $client = new LanguageClient(new MockProtocolStream(), $writer = new MockProtocolStream());
+        $projectIndex = new ProjectIndex($sourceIndex = new Index(), $dependenciesIndex = new DependenciesIndex());
+        $definitionResolver = new DefinitionResolver($projectIndex);
+        $loader = new PhpDocumentLoader(new FileSystemContentRetriever(), $projectIndex, $definitionResolver);
+        $workspace = new Server\Workspace($client, $projectIndex, $dependenciesIndex, $sourceIndex, null, $loader, null, new Configuration([ 'foo' ]));
+
+        $this->assertInstanceOf(Configuration::class, $workspace->configuration);
+
+        $changesToConfig = [ 'excludePatterns' => ['foo', 'bar'] ];
+
+        $writer->on('message', function (Message $message) use ($changesToConfig) {
+            if ($message->body->method === 'workspace/didChangeConfiguration') {
+                $this->assertEquals($message->body->params->settings, $changesToConfig);
+            }
+        });
+
+        $workspace->didChangeConfiguration([ 'settings' => $changesToConfig  ]);
+        Loop\tick(true);
+
+        $this->assertEquals($workspace->configuration->excludePatterns, $changesToConfig['excludePatterns']);
+    }
+}


### PR DESCRIPTION
Closes #159

I know that there is already #749 for this but that PR does not attempt to implement the `workspace/didChangeConfiguration` method. This PR follows the steps laid out in https://github.com/felixfbecker/php-language-server/issues/159#issuecomment-338129016

> - Introduce a Configuration class
> - Implement didChangeConfiguration
> - Whenever it changes, change the Configuration instance
> - Pass the Configuration instance to the Indexer
> - Read that setting
> - Use the glob to determine files to be indexed

The tests are currently failing but I thought I'd open an early PR to gather feeback :smile: 