### PR TITLE
Capture initialized notification

### DIFF
--- a/src/LanguageServer.php
+++ b/src/LanguageServer.php
@@ -293,6 +293,16 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     }
 
     /**
+     * The initialized notification is sent from the client to the server after the client received the result of
+     * the initialize request but before the client is sending any other request or notification to the server.
+     * The server can use the initialized notification for example to dynamically register capabilities.
+     * The initialized notification may only be sent once.
+     */
+    public function initialized() {
+        // Do nothing
+    }
+
+    /**
      * The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit
      * (otherwise the response might not be delivered correctly to the client). There is a separate exit notification that
      * asks the server to exit.


### PR DESCRIPTION
Initialized notification is specified in LSP but wasn't implemented. Without implementation JSON-RPC would throw a method not found error.

https://microsoft.github.io/language-server-protocol/specification#initialized