### PR TITLE
update jsonmapper version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "felixfbecker/language-server-protocol": "^1.0.1",
         "jetbrains/phpstorm-stubs": "dev-master",
         "microsoft/tolerant-php-parser": "0.0.*",
-        "netresearch/jsonmapper": "^1.0",
+        "netresearch/jsonmapper": "^4.0",
         "phpdocumentor/reflection-docblock": "^4.0.0",
         "psr/log": "^1.0",
         "sabre/event": "^5.0",


### PR DESCRIPTION
in the php newer versions show fatal error 
``Array and string offset access syntax with curly braces is no longer supported``

to fix this update jsonmaper package version